### PR TITLE
ENH: Enum Handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig coverage pip ophyd pyqt=5 pytest -c lightsource2-tag -c conda-forge
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig coverage pydm pip ophyd pyqt=5 pytest -c lightsource2-tag -c pydm-dev -c conda-forge -c gsecars
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ install:
   - source activate test-environment
   - pip install codecov
   - pip install -r requirements.txt
+  - pip install -r dev-requirements.txt
   #Install
   - python setup.py install
   #Setup some path environment variables for epics
@@ -58,6 +59,7 @@ before_script:
 script:
   - coverage run run_tests.py
   - coverage report -m
+  - flake8
 
 after_success:
   - codecov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flake8

--- a/run_tests.py
+++ b/run_tests.py
@@ -3,12 +3,12 @@ import sys
 import pytest
 
 if __name__ == '__main__':
-    #Show output results from every test function
-    #Show the message output for skipped and expected failures
+    # Show output results from every test function
+    # Show the message output for skipped and expected failures
     args = ['-v', '-vrxs']
 
-    #Add extra arguments
-    if len(sys.argv) >1:
+    # Add extra arguments
+    if len(sys.argv) > 1:
         args.extend(sys.argv[1:])
 
     print('pytest arguments: {}'.format(args))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def _show_widgets(pytestconfig):
         logger.info("Running tests while showing created widgets ...")
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session', autouse=True)
 def qapp():
     global application
     if application:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,9 @@ from pydm import PyDMApplication
 
 logger = logging.getLogger(__name__)
 
-#Global testing variables
+# Global testing variables
 show_widgets = False
-application  = None
+application = None
 
 
 def pytest_addoption(parser):
@@ -27,29 +27,32 @@ def pytest_addoption(parser):
     parser.addoption("--show", action="store_true", default=False,
                      help="Show the widgets produced by each test")
 
-#Create a fixture to automatically instantiate logging setup
+
+# Create a fixture to automatically instantiate logging setup
 @pytest.fixture(scope='session', autouse=True)
 def _set_level(pytestconfig):
-    #Read user input logging level
+    # Read user input logging level
     log_level = getattr(logging, pytestconfig.getoption('--log'), None)
 
-    #Report invalid logging level
+    # Report invalid logging level
     if not isinstance(log_level, int):
         raise ValueError("Invalid log level : {}".format(log_level))
 
-    #Create basic configuration
+    # Create basic configuration
     logging.basicConfig(level=log_level,
                         filename=pytestconfig.getoption('--logfile'),
                         format='%(asctime)s - %(levelname)s ' +
                                '- %(name)s - %(message)s')
 
-#Create a fixture to configure whether widgets are shown or not
+
+# Create a fixture to configure whether widgets are shown or not
 @pytest.fixture(scope='session', autouse=True)
 def _show_widgets(pytestconfig):
     global show_widgets
     show_widgets = pytestconfig.getoption('--show')
     if show_widgets:
         logger.info("Running tests while showing created widgets ...")
+
 
 @pytest.fixture(scope='module')
 def qapp():
@@ -60,17 +63,18 @@ def qapp():
         application = PyDMApplication()
     return application
 
+
 def show_widget(func):
     """
     Show a widget returned from arbitrary `func`
     """
     @wraps(func)
     def func_wrapper(*args, **kwargs):
-        #Run function grab widget
+        # Run function grab widget
         widget = func(*args, **kwargs)
         if show_widgets:
-            #Display the widget
+            # Display the widget
             widget.show()
-            #Start the application
+            # Start the application
             application.exec_()
     return func_wrapper

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -11,6 +11,7 @@ from ophyd import Device, EpicsMotor, Component as C, FormattedComponent as FC
 ###########
 # Package #
 ###########
+from typhon.utils import clean_attr
 from typhon.display import DeviceDisplay
 from .conftest import show_widget
 
@@ -57,3 +58,10 @@ def test_display(qapp):
     assert all([getattr(d, dev) in display.all_devices
                 for dev in d._sub_devices])
     return display
+
+
+def test_enum_attrs(qapp):
+    d = MockDevice("Tst:Dev", name='MockDevice')
+    d.enum_attrs = ['read1']
+    d = DeviceDisplay(d)
+    assert clean_attr('read1') in d.read_panel.enum_sigs

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -46,7 +46,7 @@ class MockDevice(Device):
 
 
 @show_widget
-def test_display(qapp):
+def test_display():
     d = MockDevice("Tst:Dev", name='MockDevice')
     display = DeviceDisplay(d)
     # We have all our signals
@@ -60,7 +60,7 @@ def test_display(qapp):
     return display
 
 
-def test_enum_attrs(qapp):
+def test_enum_attrs():
     d = MockDevice("Tst:Dev", name='MockDevice')
     d.enum_attrs = ['read1']
     d = DeviceDisplay(d)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -5,54 +5,55 @@
 ############
 # External #
 ############
-import pytest
-from ophyd.signal import EpicsSignal, EpicsSignal, EpicsSignalRO
+from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd import Device, EpicsMotor, Component as C, FormattedComponent as FC
 
 ###########
 # Package #
 ###########
 from typhon.display import DeviceDisplay
-from .conftest      import show_widget
+from .conftest import show_widget
+
 
 class MockDevice(Device):
-    #Device signals
-    read1   = C(EpicsSignalRO, ':READ1')
-    read2   = C(EpicsSignalRO, ':READ2')
-    read3   = C(EpicsSignalRO, ':READ3')
-    read4   = C(EpicsSignal,   ':READ4')
-    read5   = C(EpicsSignal,   ':READ5', write_pv=':WRITE5')
+    # Device signals
+    read1 = C(EpicsSignalRO, ':READ1')
+    read2 = C(EpicsSignalRO, ':READ2')
+    read3 = C(EpicsSignalRO, ':READ3')
+    read4 = C(EpicsSignal,   ':READ4')
+    read5 = C(EpicsSignal,   ':READ5', write_pv=':WRITE5')
     config1 = C(EpicsSignalRO, ':CFG1')
     config2 = C(EpicsSignalRO, ':CFG2')
     config3 = C(EpicsSignalRO, ':CFG3')
     config4 = C(EpicsSignal,   ':CFG4')
     config5 = C(EpicsSignal,   ':CFG5', write_pv=':CFGWRITE5')
-    misc1   = C(EpicsSignalRO, ':MISC1')
-    misc2   = C(EpicsSignalRO, ':MISC2')
-    misc3   = C(EpicsSignalRO, ':MISC3')
-    misc4   = C(EpicsSignal,   ':MISC4')
-    misc5   = C(EpicsSignal,   ':MISC5', write_pv=':MISCWRITE5')
+    misc1 = C(EpicsSignalRO, ':MISC1')
+    misc2 = C(EpicsSignalRO, ':MISC2')
+    misc3 = C(EpicsSignalRO, ':MISC3')
+    misc4 = C(EpicsSignal,   ':MISC4')
+    misc5 = C(EpicsSignal,   ':MISC5', write_pv=':MISCWRITE5')
 
-    #Component Motors
+    # Component Motors
     x = FC(EpicsMotor, 'Tst:MMS:X', name='X Axis')
     y = FC(EpicsMotor, 'Tst:MMS:Y', name='Y Axis')
     z = FC(EpicsMotor, 'Tst:MMS:Z', name='Z Axis')
 
-    #Default Signal Sorting
+    # Default Signal Sorting
     _default_read_attrs = ['read1', 'read2', 'read3', 'read4', 'read5']
     _default_configuration_attrs = ['config1', 'config2', 'config3',
                                     'config4', 'config5']
+
 
 @show_widget
 def test_display(qapp):
     d = MockDevice("Tst:Dev", name='MockDevice')
     display = DeviceDisplay(d)
-    #We have all our signals
-    assert all([getattr(d,sig) in list(display.read_panel.signals.values())
+    # We have all our signals
+    assert all([getattr(d, sig) in list(display.read_panel.signals.values())
                 for sig in d.read_attrs])
-    assert all([getattr(d,sig) in list(display.config_panel.signals.values())
+    assert all([getattr(d, sig) in list(display.config_panel.signals.values())
                 for sig in d.configuration_attrs])
-    #We have all our subdevices
+    # We have all our subdevices
     assert all([getattr(d, dev) in display.all_devices
                 for dev in d._sub_devices])
     return display

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -16,7 +16,7 @@ from .conftest import show_widget
 
 
 @show_widget
-def test_panel(qapp):
+def test_panel():
     panel = Panel(signals={
                     # Signal is its own write
                     'Standard': EpicsSignal('Tst:Pv'),
@@ -30,7 +30,7 @@ def test_panel(qapp):
 
 
 @show_widget
-def test_panel_add_enum(qapp):
+def test_panel_add_enum():
     panel = Panel()
     loc = panel.add_signal(EpicsSignal("Tst:Enum"), "Enum PV", enum=True)
     # Check our signal was added in the `enum_attrs` list

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -6,6 +6,7 @@
 # External #
 ############
 from ophyd.signal import EpicsSignal, EpicsSignalRO
+from pydm.widgets import PyDMEnumComboBox
 
 ###########
 # Package #
@@ -25,4 +26,18 @@ def test_panel(qapp):
                     # Signal is read-only
                     'Read Only': EpicsSignalRO('Tst:Pv:RO')})
     assert len(panel.signals) == 3
+    return panel
+
+
+@show_widget
+def test_panel_add_enum(qapp):
+    panel = Panel()
+    loc = panel.add_signal(EpicsSignal("Tst:Enum"), "Enum PV", enum=True)
+    # Check our signal was added in the `enum_attrs` list
+    assert "Enum PV" in panel.enum_sigs
+    # Check our signal was added a QCombobox
+    # Assume it is the last item in the button layout
+    but_layout = panel.layout().itemAtPosition(loc, 1)
+    assert isinstance(but_layout.itemAt(but_layout.count()-1).widget(),
+                      PyDMEnumComboBox)
     return panel

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -5,7 +5,6 @@
 ############
 # External #
 ############
-import pytest
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 
 ###########
@@ -14,15 +13,16 @@ from ophyd.signal import EpicsSignal, EpicsSignalRO
 from typhon.panel import Panel
 from .conftest import show_widget
 
+
 @show_widget
 def test_panel(qapp):
     panel = Panel(signals={
-                    #Signal is its own write            
-                    'Standard' : EpicsSignal('Tst:Pv'),
-                    #Signal has separate write/read
-                    'Read and Write' : EpicsSignal('Tst:Read',
-                                                   write_pv='Tst:Write'),
-                    #Signal is read-only
-                    'Read Only' : EpicsSignalRO('Tst:Pv:RO')})
+                    # Signal is its own write
+                    'Standard': EpicsSignal('Tst:Pv'),
+                    # Signal has separate write/read
+                    'Read and Write': EpicsSignal('Tst:Read',
+                                                  write_pv='Tst:Write'),
+                    # Signal is read-only
+                    'Read Only': EpicsSignalRO('Tst:Pv:RO')})
     assert len(panel.signals) == 3
     return panel

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -9,9 +9,9 @@ from functools import partial
 # External #
 ############
 from pydm.PyQt import uic
-from pydm.PyQt.QtCore import pyqtSlot, QSize
-from pydm.PyQt.QtGui  import QPushButton
-from pydm.PyQt.QtGui  import QWidget, QHBoxLayout
+from pydm.PyQt.QtCore import pyqtSlot
+from pydm.PyQt.QtGui import QPushButton
+from pydm.PyQt.QtGui import QWidget, QHBoxLayout
 
 ###########
 # Package #
@@ -20,6 +20,7 @@ from .panel import Panel
 from .utils import ui_dir, clean_attr
 
 logger = logging.getLogger(__name__)
+
 
 class DeviceDisplay(QWidget):
     """
@@ -52,9 +53,9 @@ class DeviceDisplay(QWidget):
     """
     def __init__(self, device, dark=True, read_attrs=None,
                  configuration_attrs=None, parent=None):
-        #Instantiate Widget
+        # Instantiate Widget
         super().__init__(parent=parent)
-        #Change the stylesheet
+        # Change the stylesheet
         if dark:
             try:
                 import qdarkstyle
@@ -63,26 +64,26 @@ class DeviceDisplay(QWidget):
                              "qdarkstyle package not available")
             else:
                 self.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
-        #Instantiate UI
+        # Instantiate UI
         self.ui = uic.loadUi(os.path.join(ui_dir, 'base.ui'), self)
-        #Store device
+        # Store device
         self.device = device
-        #Set Label Names
+        # Set Label Names
         self.ui.name_label.setText(self.device.name)
         self.ui.prefix_label.setText(self.device.prefix)
-        #Hide Subcomponents
+        # Hide Subcomponents
         self.ui.component_widget.hide()
-        #Create Read and Configuration Panels
-        self.read_panel   = self.create_panel(self.device.read_attrs)
+        # Create Read and Configuration Panels
+        self.read_panel = self.create_panel(self.device.read_attrs)
         self.config_panel = self.create_panel(self.device.configuration_attrs,
                                               button=self.ui.config_button)
-        #Add read panel above config button
+        # Add read panel above config button
         rd_idx = self.ui.main_layout.indexOf(self.ui.config_button)
         self.ui.main_layout.insertWidget(rd_idx, self.read_panel)
-        #Add config panel below config button
+        # Add config panel below config button
         cfg_idx = self.ui.main_layout.indexOf(self.ui.config_button)+1
         self.ui.main_layout.insertWidget(cfg_idx, self.config_panel)
-        #Catch the rest of the signals add to misc panel below misc_button
+        # Catch the rest of the signals add to misc panel below misc_button
         misc_sigs = [sig for sig in self.device.component_names
                      if sig not in (self.device.read_attrs
                                     + self.device.configuration_attrs
@@ -91,10 +92,10 @@ class DeviceDisplay(QWidget):
                                             button=self.ui.misc_button)
         misc_idx = self.ui.main_layout.indexOf(self.ui.misc_button)+1
         self.ui.main_layout.insertWidget(misc_idx, self.misc_panel)
-        #Hide config/misc panels
+        # Hide config/misc panels
         self.config_panel.hide()
         self.misc_panel.hide()
-        #Create buttons for subcomponents
+        # Create buttons for subcomponents
         self.sub_button_layout = None
         for dev_name in self.device._sub_devices:
             self.add_subdevice(getattr(self.device, dev_name))
@@ -127,12 +128,12 @@ class DeviceDisplay(QWidget):
         -------
         panel : :class:`.typhon.Panel`
         """
-        #Create dictionary mapping of alias -> EpicsSignal
+        # Create dictionary mapping of alias -> EpicsSignal
         sig_dict = dict((clean_attr(sig), getattr(self.device, sig))
                         for sig in signal_names)
-        #Create panel
+        # Create panel
         panel = Panel(signals=sig_dict, parent=self)
-        #Allow button to hide and show panel
+        # Allow button to hide and show panel
         if button:
             button.toggled.connect(partial(self.toggle_panel, panel=panel))
         return panel
@@ -149,25 +150,25 @@ class DeviceDisplay(QWidget):
         device : ophyd.Device
         """
         logger.info("Adding device %s ...", device.name)
-        #Add our button layout if not created
+        # Add our button layout if not created
         if not self.sub_button_layout:
             logger.debug("Creating button layout for subdevices ...")
             self.sub_button_layout = QHBoxLayout()
             self.ui.main_layout.insertLayout(1, self.sub_button_layout)
-        #Create device display
+        # Create device display
         sub_display = DeviceDisplay(device)
         idx = self.ui.component_stack.addWidget(sub_display)
-        #Create button
+        # Create button
         but = QPushButton()
         but.setText(clean_attr(device.name))
         self.sub_button_layout.addWidget(but)
-        #Connect button
+        # Connect button
         but.clicked.connect(partial(self.show_subdevice, idx=idx))
 
     @pyqtSlot(bool)
     def toggle_panel(self, checked, panel):
         """
-	Toggle the visibility of a panel
+        Toggle the visibility of a panel
 
         Parameters
         ----------
@@ -192,8 +193,8 @@ class DeviceDisplay(QWidget):
         idx : int
             Index of subdevice widget
         """
-        #Show the component widget if hidden
+        # Show the component widget if hidden
         if self.ui.component_widget.isHidden():
             self.ui.component_widget.show()
-        #Show the correct subdevice widget
+        # Show the correct subdevice widget
         self.ui.component_stack.setCurrentIndex(idx)

--- a/typhon/panel.py
+++ b/typhon/panel.py
@@ -7,13 +7,13 @@ import logging
 # External #
 ############
 from pydm.PyQt.QtGui import QHBoxLayout, QFont, QLabel, QWidget, QGridLayout
-from pydm.widgets.line_edit import PyDMLineEdit
+from pydm.widgets import PyDMLineEdit
 
 #############
 #  Package  #
 #############
 from .utils import channel_name
-from .widgets import TyphonLabel
+from .widgets import TyphonComboBox, TyphonLabel
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +27,20 @@ class Panel(QWidget):
     signals : OrderedDict, optional
         Signals to include in the panel
 
+    enum_sigs : list, optional
+        Force certain PV controls to be QComboxBoxes instead of LineEdits.
+        Useful for PVs that are expecting a certain subset of strings for their
+        input. Should match the keys provided in the :param:`.signals`
+        dictionary
+
     parent : QWidget, optional
         Parent of panel
     """
-    def __init__(self, signals=None, parent=None):
+    def __init__(self, signals=None, enum_sigs=None, parent=None):
         super().__init__(parent=parent)
+        # Store signal information
         self.signals = dict()
+        self.enum_sigs = enum_sigs or list()
         # Set QGridLayout to widget
         self._layout = QGridLayout()
         self.setLayout(self._layout)
@@ -41,7 +49,7 @@ class Panel(QWidget):
             for name, sig in signals.items():
                 self.add_signal(sig, name)
 
-    def add_signal(self, signal, name):
+    def add_signal(self, signal, name, enum=False):
         """
         Parameters
         ----------
@@ -50,8 +58,21 @@ class Panel(QWidget):
 
         name : str
             Name of signal to display
+
+        enum : bool, optional
+            Consider the PV to be an `Enum` and provide a QCombobox to control
+            it rather than a LineEdit
+
+        Returns
+        -------
+        loc : int
+            Row number that the signal information was added to in the
+            `Typhon.Panel.layout()``
         """
         logger.debug("Adding signal %s", name)
+        # Add our signal to enum list
+        if enum:
+            self.enum_sigs.append(name)
         # Create label
         label = QLabel(self)
         label.setText(name)
@@ -66,13 +87,22 @@ class Panel(QWidget):
         val_display.addWidget(ro)
         # Add write
         if hasattr(signal, '_write_pv'):
-            logger.debug("Adding LineEdit for %s", name)
-            edit = PyDMLineEdit(init_channel=channel_name(signal._write_pv),
-                                parent=self)
+            ch = channel_name(signal._write_pv)
+            # Check whether our device is an enum or not
+            if (name in self.enum_sigs or (signal.connected
+                                           and signal._write_pv.enum_strs)):
+                edit = TyphonComboBox(init_channel=ch, parent=self)
+            else:
+                logger.debug("Adding LineEdit for %s", name)
+                edit = PyDMLineEdit(init_channel=ch, parent=self)
+            # Add our control widget to layout
             val_display.addWidget(edit)
         # Add displays to panel
-        self._layout.addWidget(label, len(self.signals), 0)
-        self._layout.addLayout(val_display, len(self.signals), 1)
+        loc = len(self.signals)
+        self._layout.addWidget(label, loc, 0)
+        self._layout.addLayout(val_display, loc, 1)
 
         # Store signal
         self.signals[name] = signal
+
+        return loc

--- a/typhon/panel.py
+++ b/typhon/panel.py
@@ -6,8 +6,7 @@ import logging
 ############
 # External #
 ############
-from pydm.PyQt.QtCore import QSize
-from pydm.PyQt.QtGui  import QHBoxLayout, QFont, QLabel, QWidget, QGridLayout
+from pydm.PyQt.QtGui import QHBoxLayout, QFont, QLabel, QWidget, QGridLayout
 from pydm.widgets.line_edit import PyDMLineEdit
 
 #############
@@ -17,6 +16,7 @@ from .utils import channel_name
 from .widgets import TyphonLabel
 
 logger = logging.getLogger(__name__)
+
 
 class Panel(QWidget):
     """
@@ -32,11 +32,11 @@ class Panel(QWidget):
     """
     def __init__(self, signals=None, parent=None):
         super().__init__(parent=parent)
-        self.signals  = dict()
-        #Set QGridLayout to widget
-        self._layout   = QGridLayout()
+        self.signals = dict()
+        # Set QGridLayout to widget
+        self._layout = QGridLayout()
         self.setLayout(self._layout)
-        #Add supplied signals
+        # Add supplied signals
         if signals:
             for name, sig in signals.items():
                 self.add_signal(sig, name)
@@ -52,26 +52,27 @@ class Panel(QWidget):
             Name of signal to display
         """
         logger.debug("Adding signal %s", name)
-        #Create label
+        # Create label
         label = QLabel(self)
         label.setText(name)
         label_font = QFont()
         label_font.setBold(True)
         label.setFont(label_font)
-        #Create signal display
+        # Create signal display
         val_display = QHBoxLayout()
-        #Add readback
-        val_display.addWidget(TyphonLabel(init_channel=channel_name(signal._read_pv),
-                                          parent=self))
-        #Add write
+        # Add readback
+        ro = TyphonLabel(init_channel=channel_name(signal._read_pv),
+                         parent=self)
+        val_display.addWidget(ro)
+        # Add write
         if hasattr(signal, '_write_pv'):
             logger.debug("Adding LineEdit for %s", name)
-            val_display.addWidget(PyDMLineEdit(init_channel=channel_name(signal._write_pv),
-                                               parent=self))
-        #Add displays to panel
+            edit = PyDMLineEdit(init_channel=channel_name(signal._write_pv),
+                                parent=self)
+            val_display.addWidget(edit)
+        # Add displays to panel
         self._layout.addWidget(label, len(self.signals), 0)
         self._layout.addLayout(val_display, len(self.signals), 1)
 
-        #Store signal
+        # Store signal
         self.signals[name] = signal
-

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -16,11 +16,13 @@ import os.path
 
 ui_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'ui')
 
+
 def channel_name(pv):
     """
     Create a valid PyDM channel from a PV name
     """
     return 'ca://' + pv.pvname
+
 
 def clean_attr(attr):
     """

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -5,12 +5,13 @@
 ############
 # External #
 ############
-from pydm.PyQt.QtCore   import QSize, Qt
+from pydm.PyQt.QtCore import QSize, Qt
 from pydm.widgets.label import PyDMLabel
 
 ###########
 # Package #
 ###########
+
 
 class TyphonLabel(PyDMLabel):
     """
@@ -23,7 +24,5 @@ class TyphonLabel(PyDMLabel):
         self.setAlignment(Qt.AlignCenter)
 
     def sizeHint(self):
-        #This is to match the PyDMLineEdit sizeHint
+        # This is to match the PyDMLineEdit sizeHint
         return QSize(100, 30)
-
-

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -6,17 +6,24 @@
 # External #
 ############
 from pydm.PyQt.QtCore import QSize, Qt
-from pydm.widgets.label import PyDMLabel
+from pydm.widgets import PyDMLabel, PyDMEnumComboBox
 
 ###########
 # Package #
 ###########
 
 
+class TyphonComboBox(PyDMEnumComboBox):
+    """
+    Reimplementation of PyDMEnumComboBox to set some custom defaults
+    """
+    def sizeHint(self):
+        # This is to match teh PyDMLineEdit sizeHint
+        return QSize(100, 30)
+
+
 class TyphonLabel(PyDMLabel):
     """
-    TyphonLabel
-
     Reimplemtation of PyDMLabel to set some custom defaults
     """
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Certain PVs should not have a `PyDMLineEdit` given to them for control. Instead, we can use the the `PyDMComboBox` to show a limited amount of operations for the user. We do not need to identify what the specific states associated with the PV are, just that they are present. 

In order to still allow users to have ComboBoxes when creating a display for an offline device. Users can either set the `enum_attrs` attribute on their device, or explicitly add signals with the `enum` param on `Panel.add_signal`

Also:
* Now running flake8 in Travis. 
* Entire library now passes flake8 tests
* Cleaned the tests directory (qapp is instatiated automatically)
* PyDM is installed via conda recipe from `pydm-dev`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #8 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added two tests; one for the panel and one for the display
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Clarified enum handling in both `Panel` and `DeviceDisplay` docstrings

## Screenshots:
Example of ComboBox use
<img width="339" alt="screen shot 2017-11-06 at 7 39 43 pm" src="https://user-images.githubusercontent.com/25753048/32476115-47b0bbf2-c32a-11e7-8790-26c0ab43f852.png">

