### PR TITLE
Plot device hints

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -8,6 +8,7 @@
 import pytest
 from ophyd.signal import EpicsSignal, EpicsSignalRO
 from ophyd import Device, EpicsMotor, Component as C, FormattedComponent as FC
+from ophyd.tests.conftest import using_fake_epics_pv
 
 ###########
 # Package #
@@ -55,11 +56,13 @@ class MockDevice(Device):
         pass
 
 
+@using_fake_epics_pv
 @pytest.fixture(scope='module')
 def device():
     return MockDevice("Tst:Dev", name="MockDevice")
 
 
+@using_fake_epics_pv
 @show_widget
 def test_display(device):
     display = DeviceDisplay(device)
@@ -76,12 +79,14 @@ def test_display(device):
     return display
 
 
+@using_fake_epics_pv
 def test_enum_attrs(device):
     device.enum_attrs = ['read1']
     display = DeviceDisplay(device)
     assert clean_attr('read1') in display.read_panel.enum_sigs
 
 
+@using_fake_epics_pv
 @show_widget
 def test_display_with_funcs(device):
     display = DeviceDisplay(device, methods=[device.insert,
@@ -91,4 +96,12 @@ def test_display_with_funcs(device):
     # Assert we have all our specified functions
     assert 'insert' in display.methods
     assert 'remove' in display.methods
+    return display
+
+@using_fake_epics_pv
+@show_widget
+def test_display_with_hints(device):
+    device.hints = {'fields': [device.name + '_read1']}
+    display = DeviceDisplay(device)
+    assert len(display.ui.hint_plot.curves) == 1
     return display

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -98,6 +98,7 @@ def test_display_with_funcs(device):
     assert 'remove' in display.methods
     return display
 
+
 @using_fake_epics_pv
 @show_widget
 def test_display_with_hints(device):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -78,6 +78,7 @@ class DeviceDisplay(QWidget):
     """
     default_curve_opts = {'lineStyle': Qt.SolidLine, 'symbol': 'o',
                           'lineWidth': 2, 'symbolSize': 4}
+
     def __init__(self, device, dark=True, methods=None, read_attrs=None,
                  configuration_attrs=None, parent=None):
         # Instantiate Widget
@@ -141,7 +142,7 @@ class DeviceDisplay(QWidget):
                 # to the hint_panel if it is a number and not a string
                 sig_desc = self.device_description[field]
                 if sig_desc['dtype'] == 'number':
-                    self.add_plotted_signal(sig_desc['source'])
+                    self.add_plotted_signal(clean_source(sig_desc['source']))
                 else:
                     logger.debug("Not adding %s because it is not a number",
                                  field)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -1,6 +1,7 @@
 ############
 # Standard #
 ############
+import copy
 import os.path
 import logging
 from functools import partial
@@ -9,15 +10,15 @@ from functools import partial
 # External #
 ############
 from pydm.PyQt import uic
-from pydm.PyQt.QtCore import pyqtSlot
+from pydm.PyQt.QtCore import pyqtSlot, Qt
 from pydm.PyQt.QtGui import QGroupBox, QWidget, QHBoxLayout, QPushButton
 
 ###########
 # Package #
 ###########
 from .func import FunctionPanel
-from .utils import ui_dir, clean_attr
 from .panel import SignalPanel
+from .utils import ui_dir, clean_attr, clean_source, channel_name
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,19 @@ class DeviceDisplay(QWidget):
     configuration_attrs : list, optional
         Attributes to be used as configuration_attrs. This will also change the
         ``device.configuration_attrs``
+
+    Attributes
+    ----------
+    hint_plot:
+
+    read_panel:
+
+    config_panel:
+
+    misc_panel:
     """
+    default_curve_opts = {'lineStyle': Qt.SolidLine, 'symbol': 'o',
+                          'lineWidth': 2, 'symbolSize': 4}
     def __init__(self, device, dark=True, methods=None, read_attrs=None,
                  configuration_attrs=None, parent=None):
         # Instantiate Widget
@@ -82,6 +95,7 @@ class DeviceDisplay(QWidget):
         self.ui = uic.loadUi(os.path.join(ui_dir, 'base.ui'), self)
         # Store device
         self.device = device
+        self.device_description = self.device.describe()
         # Set Label Names
         self.ui.name_label.setText(self.device.name)
         self.ui.prefix_label.setText(self.device.prefix)
@@ -120,6 +134,22 @@ class DeviceDisplay(QWidget):
         # Hide if no methods are given
         if not self.methods:
             self.method_panel.hide()
+        # Add our hints
+        for field in getattr(self.device, 'hints', {}).get('fields', list()):
+            try:
+                # Get a description of the signal. Add the the PV name
+                # to the hint_panel if it is a number and not a string
+                sig_desc = self.device_description[field]
+                if sig_desc['dtype'] == 'number':
+                    self.add_plotted_signal(sig_desc['source'])
+                else:
+                    logger.debug("Not adding %s because it is not a number",
+                                 field)
+            except KeyError as exc:
+                logger.error("Unable to find PV name of %s", field)
+        # If we did not get any hints
+        if not self.ui.hint_plot.curves:
+            self.ui.hint_plot.hide()
 
     @property
     def all_devices(self):
@@ -195,10 +225,29 @@ class DeviceDisplay(QWidget):
         # Create button
         but = QPushButton()
         but.setText(clean_attr(device.name))
-        but.setCheckable(True)
         self.sub_device_group.layout().addWidget(but)
         # Connect button
         but.clicked.connect(partial(self.show_subdevice, idx=idx))
+
+    def add_plotted_signal(self, pv, **kwargs):
+        """
+        Add a signal to the PyDMTimePlot
+
+        Parameters
+        ----------
+        pvname : str
+            Name of PV
+
+        kwargs:
+            All keywords are passed directly to ``PyDMTimePlot.addYChannel``
+        """
+        # Show our plot if it was previously hidden
+        if self.ui.hint_plot.isHidden():
+            self.ui.hint_plot.show()
+        # Combine user supplied options with defaults
+        plot_opts = copy.copy(self.default_curve_opts)
+        plot_opts.update(kwargs)
+        self.ui.hint_plot.addYChannel(y_channel=channel_name(pv), **plot_opts)
 
     @pyqtSlot()
     def show_subdevice(self, idx):

--- a/typhon/func.py
+++ b/typhon/func.py
@@ -295,7 +295,7 @@ class FunctionDisplay(QGroupBox):
         # just pass it on. Otherwise, collect information
         # from the appropriate widgets
         if not self.signature.parameters:
-            func = self.func()
+            func = self.func
         else:
             kwargs = dict()
             # Gather information from parameter widgets

--- a/typhon/panel.py
+++ b/typhon/panel.py
@@ -155,12 +155,12 @@ class SignalPanel(Panel):
         # Create signal display
         val_display = QHBoxLayout()
         # Add readback
-        ro = TyphonLabel(init_channel=channel_name(signal._read_pv),
+        ro = TyphonLabel(init_channel=channel_name(signal._read_pv.pvname),
                          parent=self)
         val_display.addWidget(ro)
         # Add write
         if hasattr(signal, '_write_pv'):
-            ch = channel_name(signal._write_pv)
+            ch = channel_name(signal._write_pv.pvname)
             # Check whether our device is an enum or not
             if (name in self.enum_sigs or (signal.connected
                                            and signal._write_pv.enum_strs)):

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -31,7 +31,7 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="main_layout" stretch="0">
+     <layout class="QVBoxLayout" name="main_layout" stretch="0,0">
       <property name="sizeConstraint">
        <enum>QLayout::SetFixedSize</enum>
       </property>
@@ -105,6 +105,50 @@
         </layout>
        </widget>
       </item>
+      <item>
+       <widget class="PyDMTimePlot" name="hint_plot">
+        <property name="minimumSize">
+         <size>
+          <width>350</width>
+          <height>350</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="showXGrid">
+         <bool>true</bool>
+        </property>
+        <property name="showYGrid">
+         <bool>true</bool>
+        </property>
+        <property name="axisColor">
+         <color>
+          <red>212</red>
+          <green>212</green>
+          <blue>212</blue>
+         </color>
+        </property>
+        <property name="showLegend">
+         <bool>true</bool>
+        </property>
+        <property name="mouseEnabledX" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bufferSize">
+         <number>2500</number>
+        </property>
+        <property name="timeSpan">
+         <double>30.000000000000000</double>
+        </property>
+        <property name="updateInterval">
+         <double>0.500000000000000</double>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -174,6 +218,13 @@
   <zorder>component_widget</zorder>
   <zorder>main_widget</zorder>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMTimePlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.timeplot</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -23,11 +23,13 @@ def channel_name(pv):
     """
     return 'ca://' + pv
 
+
 def clean_attr(attr):
     """
     Create a nicer, human readable alias from a Python attribute name
     """
     return ' '.join([word[0].upper() + word[1:] for word in attr.split('_')])
+
 
 def clean_source(source):
     """

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -21,11 +21,16 @@ def channel_name(pv):
     """
     Create a valid PyDM channel from a PV name
     """
-    return 'ca://' + pv.pvname
-
+    return 'ca://' + pv
 
 def clean_attr(attr):
     """
     Create a nicer, human readable alias from a Python attribute name
     """
     return ' '.join([word[0].upper() + word[1:] for word in attr.split('_')])
+
+def clean_source(source):
+    """
+    Strip the PV prefix off the `source` returned from an Ophyd description
+    """
+    return source.lstrip('PV:')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Include a `PyDMTimePlot` that plots devices `hints`. The device is queried for an attribute `hints` which is expected to be a dictionary which contains a list under the key `fields`. Each of these fields is then looked at in the `device.describe()` dictionary to find the actual PV name. This is then passed to `add_plotted_signal` to add to the `DeviceDisplay.hint_plot`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test to `tests/test_display`. All `EpicsMotor` sub-devices will also have plots.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Appropriate docstrings added

## Screenshots:
<img width="435" alt="screen shot 2017-11-21 at 1 35 51 pm" src="https://user-images.githubusercontent.com/25753048/33098094-091a1990-cec1-11e7-806d-d8531262983d.png">
