### PR TITLE
Refactoring

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -67,23 +67,18 @@ def device():
 def test_display(device):
     display = DeviceDisplay(device)
     # We have all our signals
-    shown_read_sigs = list(display.read_panel.signals.values())
-    assert all([getattr(device, sig) in shown_read_sigs
+    shown_read_sigs = list(display.read_panel.pvs.keys())
+    assert all([clean_attr(sig) in shown_read_sigs
                 for sig in device.read_attrs])
-    shown_cfg_sigs = list(display.config_panel.signals.values())
-    assert all([getattr(device, sig) in shown_cfg_sigs
+    shown_cfg_sigs = list(display.config_panel.pvs.keys())
+    assert all([clean_attr(sig) in shown_cfg_sigs
                 for sig in device.configuration_attrs])
     # We have all our subdevices
-    assert all([getattr(device, dev) in display.all_devices
+    sub_devices = [getattr(disp, 'device', None)
+                   for disp in display.ui.component_stack.children()]
+    assert all([getattr(device, dev) in sub_devices
                 for dev in device._sub_devices])
     return display
-
-
-@using_fake_epics_pv
-def test_enum_attrs(device):
-    device.enum_attrs = ['read1']
-    display = DeviceDisplay(device)
-    assert clean_attr('read1') in display.read_panel.enum_sigs
 
 
 @using_fake_epics_pv

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -23,134 +23,63 @@ from .utils import ui_dir, clean_attr, clean_source, channel_name
 logger = logging.getLogger(__name__)
 
 
-class DeviceDisplay(QWidget):
+class TyphonDisplay(QWidget):
     """
-    Display for an Ophyd Device
+    Generalized Typhon display
 
-    The DeviceDisplay examines the supplied Ophyd Device and maps the contained
-    signals into three separate panels; read, configuration, and miscellaneous.
-    This allows the operator to quickly show and hide the information that is
-    most pertinent to their current task. The supplied Device is also queried
-    for the components which are not signals, but sub-devices. These are given
-    their own DeviceDisplays and placed in a QStackedWidget that can optionally
-    be shown and hidden based on the operators request.
+    This widget lays out all of the architecture for a general Typhon display.
+    The structure matches an ophyd Device, but for this specific instantation,
+    one is not required to be given. There are four main panels are available;
+    :attr:`.read_panel`. :attr:`.config_panel, :attr:`.method_panel`. These
+    give four separate panels provide a quick way to organize signals and
+    methods by their importance to an operator. In addition, crucial signals
+    can be added to a PyDMTimePlot under the attribute :attr:`.hint_plot`.
+    Because each panel can be hidden interactively, the screen works as both an
+    expert and novice entry point for users. By default, widgets are hidden
+    until contents are added. For instance, if you do not add any methods to
+    the main panel it will not be visible.
 
+    This device is the bare bones implementation in the event that someone
+    might want to collect a random group of signals and devices together to
+    create a screen. A more automated display generator is available  in the
+    :class:`.DeviceDisplay`
 
     Parameters
     ----------
-    device : ophyd.Device
+    name : str
+        Title displayed on the widget
 
     parent : QWidget, optional
-
-    methods : list, optional
-        List of callable functions to display in the interface
-
-    dark : bool, optional
-        Choice to use the `qdarkstyle` stylesheet
-
-    read_attrs : list, optional
-        Attributes to be used as read_attrs. This will also change the
-        ``device.read_attrs``
-
-    configuration_attrs : list, optional
-        Attributes to be used as configuration_attrs. This will also change the
-        ``device.configuration_attrs``
-
-    Attributes
-    ----------
-    hint_plot:
-
-    read_panel:
-
-    config_panel:
-
-    misc_panel:
     """
     default_curve_opts = {'lineStyle': Qt.SolidLine, 'symbol': 'o',
                           'lineWidth': 2, 'symbolSize': 4}
 
-    def __init__(self, device, dark=True, methods=None, read_attrs=None,
-                 configuration_attrs=None, parent=None):
+    def __init__(self, name, parent=None):
         # Instantiate Widget
         super().__init__(parent=parent)
-        # Change the stylesheet
-        if dark:
-            try:
-                import qdarkstyle
-            except ImportError:
-                logger.error("Can not use dark theme, "
-                             "qdarkstyle package not available")
-            else:
-                self.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
         # Instantiate UI
         self.ui = uic.loadUi(os.path.join(ui_dir, 'base.ui'), self)
-        # Store device
-        self.device = device
-        self.device_description = self.device.describe()
         # Set Label Names
-        self.ui.name_label.setText(self.device.name)
-        self.ui.prefix_label.setText(self.device.prefix)
-
-        # Handle Component Devices
-        # Create buttons for subcomponents
+        self.ui.name_label.setText(name)
+        # Create Panels
         self.sub_device_group = None
-        for dev_name in self.device._sub_devices:
-            self.add_subdevice(getattr(self.device, dev_name))
-        # Hide Subcomponents
-        self.ui.component_widget.hide()
-
-        # Create Panel Configurations
-        # Create read and configuration panels
-        self.read_panel = self.create_panel("Read", self.device.read_attrs)
-        # Hide control of read_panel
-        self.read_panel.hide_button.hide()
-        self.config_panel = self.create_panel("Configuration",
-                                              self.device.configuration_attrs)
-        # Catch the rest of the signals add to misc panel below misc_button
-        misc_sigs = [sig for sig in self.device.component_names
-                     if sig not in (self.device.read_attrs
-                                    + self.device.configuration_attrs
-                                    + self.device._sub_devices)]
-        self.misc_panel = self.create_panel("Miscellaneous", misc_sigs)
-        # Create method panel
-        self.method_panel = FunctionPanel(methods, parent=self)
+        self.method_panel = FunctionPanel(parent=self)
+        self.read_panel = SignalPanel("Read", parent=self)
+        self.config_panel = SignalPanel("Configuration", parent=self)
+        self.misc_panel = SignalPanel("Miscellaneous", parent=self)
         # Add all the panels
         self.ui.main_layout.addWidget(self.read_panel)
         self.ui.main_layout.addWidget(self.method_panel)
         self.ui.main_layout.addWidget(self.config_panel)
         self.ui.main_layout.addWidget(self.misc_panel)
-        # Hide config/misc panels
+        # Hide control of read_panel
+        self.read_panel.hide_button.hide()
+        # Hide widgets until signals are added to them
+        self.ui.component_widget.hide()
         self.config_panel.show_contents(False)
         self.misc_panel.show_contents(False)
-        # Hide if no methods are given
-        if not self.methods:
-            self.method_panel.hide()
-        # Add our hints
-        for field in getattr(self.device, 'hints', {}).get('fields', list()):
-            try:
-                # Get a description of the signal. Add the the PV name
-                # to the hint_panel if it is a number and not a string
-                sig_desc = self.device_description[field]
-                if sig_desc['dtype'] == 'number':
-                    self.add_plotted_signal(clean_source(sig_desc['source']))
-                else:
-                    logger.debug("Not adding %s because it is not a number",
-                                 field)
-            except KeyError as exc:
-                logger.error("Unable to find PV name of %s", field)
-        # If we did not get any hints
-        if not self.ui.hint_plot.curves:
-            self.ui.hint_plot.hide()
-
-    @property
-    def all_devices(self):
-        """
-        List of devices contained in the screen
-        """
-        return [self.device] + [self.ui.component_stack.widget(i).device
-                                for i in range(self.ui.component_stack.count())
-                                if hasattr(self.ui.component_stack.widget(i),
-                                           'device')]
+        self.method_panel.hide()
+        self.ui.hint_plot.hide()
 
     @property
     def methods(self):
@@ -159,45 +88,20 @@ class DeviceDisplay(QWidget):
         """
         return self.method_panel.methods
 
-    def create_panel(self, title, signal_names, **kwargs):
+    def add_subdisplay(self, name, display):
         """
-        Create a panel from a set of device signals
+
+        This creates another display for a subcomponent and a QPushButton that
+        will bring the display to the foreground
 
         Parameters
         ----------
-        title :str
-            Name of Panel
+        name : str
+            Name to place on QPushButton
 
-        signal_names : list
-            Name of signals to add to panel. Must be a component of ``device``
-
-        kwargs:
-            All keywords are passed to the :class:`typhon.SignalPanel`. The
-            signal dictionary is generated from the `signal_names` parameter.
-
-        Returns
-        -------
-        panel : :class:`.typhon.Panel`
+        display : QWidget
+            QWidget to associate with button
         """
-        # Create dictionary mapping of alias -> EpicsSignal
-        sig_dict = dict((clean_attr(sig), getattr(self.device, sig))
-                        for sig in signal_names)
-        # Create panel
-        panel = SignalPanel(title, signals=sig_dict, **kwargs)
-        return panel
-
-    def add_subdevice(self, device):
-        """
-        Add a subdevice to the `component_widget` stack
-
-        This creates another DeviceDisplay for the subcomponent and a
-        QPushButton that will bring the display to the forground
-
-        Parameters
-        ----------
-        device : ophyd.Device
-        """
-        logger.debug("Adding device %s ...", device.name)
         # Add our button layout if not created
         if not self.sub_device_group:
             logger.debug("Creating button layout for subdevices ...")
@@ -205,18 +109,36 @@ class DeviceDisplay(QWidget):
             self.sub_device_group.setLayout(QHBoxLayout())
             self.ui.main_layout.insertWidget(1, self.sub_device_group)
         # Create device display
-        sub_display = DeviceDisplay(device)
-        idx = self.ui.component_stack.addWidget(sub_display)
+        idx = self.ui.component_stack.addWidget(display)
         # Create button
         but = QPushButton()
-        but.setText(clean_attr(device.name))
+        but.setText(name)
         self.sub_device_group.layout().addWidget(but)
         # Connect button
         but.clicked.connect(partial(self.show_subdevice, idx=idx))
 
-    def add_plotted_signal(self, pv, **kwargs):
+    def add_subdevice(self, device, methods=None):
         """
-        Add a signal to the PyDMTimePlot
+        Add a subdevice to the `component_widget` stack
+
+        Parameters
+        ----------
+        device : ophyd.Device
+
+        methods : list of callables, optional
+
+        """
+        logger.debug("Creating subdisplay for %s", device.name)
+        self.add_subdisplay(device.name, DeviceDisplay(device,
+                                                       methods=methods,
+                                                       parent=self))
+
+    def add_pv_to_plot(self, pv, **kwargs):
+        """
+        Add a PV to the PyDMTimePlot
+
+        The default style of the curve is determined by
+        :attr:`.default_curve_opts`. Though these can be overridden
 
         Parameters
         ----------
@@ -249,3 +171,66 @@ class DeviceDisplay(QWidget):
         # Show the correct subdevice widget
         self.ui.component_stack.setCurrentIndex(idx)
 
+
+class DeviceDisplay(TyphonDisplay):
+    """
+    Display an ophyd Device
+
+    Using the panels created by the inherited :class:`.TyphonDisplay` the
+    sub-devices and signals are added to the appropriate places in the widget.
+    The display introspects the ``read_attrs``, ``configuration_attrs``,
+    ``component_names`` and ``_sub_devices`` to find the signal names and
+    heirarchy.
+
+    Parameters
+    ----------
+    device : ophyd.Device
+        Main ophyd device to display
+
+    methods : list of callables, optional
+        List of callables to pass to :meth:`.FunctionPanel.add_panel`
+
+    parent : QWidget, optional
+    """
+    def __init__(self, device, methods=None, parent=None):
+        super().__init__(device.name, parent=parent)
+        # Examine and store device for later reference
+        self.device = device
+        self.device_description = self.device.describe()
+        # Handle child devices
+        for dev_name in self.device._sub_devices:
+            self.add_subdevice(getattr(self.device, dev_name))
+
+        # Create read and configuration panels
+        for attr in self.device.read_attrs:
+            self.read_panel.add_signal(getattr(self.device, attr),
+                                       clean_attr(attr))
+
+        for attr in self.device.configuration_attrs:
+            self.config_panel.add_signal(getattr(self.device, attr),
+                                         clean_attr(attr))
+        # Catch the rest of the signals add to misc panel below misc_button
+        for attr in self.device.component_names:
+            if attr not in (self.device.read_attrs
+                            + self.device.configuration_attrs
+                            + self.device._sub_devices):
+                self.misc_panel.add_signal(getattr(self.device, attr),
+                                           clean_attr(attr))
+        # Add our methods to the panel
+        methods = methods or list()
+        for method in methods:
+                self.method_panel.add_method(method)
+
+        # Add our hints
+        for field in getattr(self.device, 'hints', {}).get('fields', list()):
+            try:
+                # Get a description of the signal. Add the the PV name
+                # to the hint_panel if it is a number and not a string
+                sig_desc = self.device_description[field]
+                if sig_desc['dtype'] == 'number':
+                    self.add_pv_to_plot(clean_source(sig_desc['source']))
+                else:
+                    logger.debug("Not adding %s because it is not a number",
+                                 field)
+            except KeyError as exc:
+                logger.error("Unable to find PV name of %s", field)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -35,16 +35,6 @@ class DeviceDisplay(QWidget):
     their own DeviceDisplays and placed in a QStackedWidget that can optionally
     be shown and hidden based on the operators request.
 
-    In order to accomodate an offline creation mode, each device is
-    additionally checked for an ``enum_attrs`` property which contains which
-    device signals should be passed to :class:`.Panel` in ``enum_sigs`. If
-    the device you are creating a display for is avaiable through Channel
-    Access, you do not have to worry about this step, as ``typhon`` will
-    introspect the PV information to find which PVs are enums. However,
-    offline, this information is not available and a user may want their screen
-    to have certain EPICS variables displayed as QComboBoxes. In this case,
-    devices and the sub-component devices should have the relevant attributes
-    flagged under `enum_attrs`
 
     Parameters
     ----------
@@ -184,7 +174,6 @@ class DeviceDisplay(QWidget):
         kwargs:
             All keywords are passed to the :class:`typhon.SignalPanel`. The
             signal dictionary is generated from the `signal_names` parameter.
-            The device is also queried for :attr:`.enum_attrs`
 
         Returns
         -------
@@ -193,13 +182,8 @@ class DeviceDisplay(QWidget):
         # Create dictionary mapping of alias -> EpicsSignal
         sig_dict = dict((clean_attr(sig), getattr(self.device, sig))
                         for sig in signal_names)
-        # Search for fixed enum attrs
-        enum_attrs = [clean_attr(sig)
-                      for sig in getattr(self.device, 'enum_attrs', list())]
-        enum_attrs.extend(kwargs.pop('enum_attrs', list()))
         # Create panel
-        panel = SignalPanel(title, signals=sig_dict,
-                            enum_sigs=enum_attrs, **kwargs)
+        panel = SignalPanel(title, signals=sig_dict, **kwargs)
         return panel
 
     def add_subdevice(self, device):
@@ -264,3 +248,4 @@ class DeviceDisplay(QWidget):
             self.ui.component_widget.show()
         # Show the correct subdevice widget
         self.ui.component_stack.setCurrentIndex(idx)
+

--- a/typhon/func.py
+++ b/typhon/func.py
@@ -420,7 +420,6 @@ class FunctionPanel(Panel):
         self.methods[func_name] = widget
         # Add to panel. Make sure that if this is
         # the first added method that the panel is visible
-        if self.contents.isHidden():
-            self.contents.show()
+        self.show_contents(True)
         self.contents.layout().insertWidget(len(self.methods),
                                             widget)

--- a/typhon/panel.py
+++ b/typhon/panel.py
@@ -76,6 +76,7 @@ class Panel(QWidget):
         # Show or hide the widget if the contents exist
         if self.contents:
             if show:
+                self.show()
                 self.contents.show()
             else:
                 self.contents.hide()
@@ -179,4 +180,6 @@ class SignalPanel(Panel):
         self.contents.layout().addLayout(val_display, loc, 1)
         # Store signal
         self.pvs[name] = (read_pv, write_pv)
+        # Check that our widget is not hidden
+        self.show_contents(True)
         return loc

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -78,18 +78,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="prefix_label">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>(Device Prefix)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -138,8 +126,14 @@
         <property name="mouseEnabledX" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="curves">
+         <stringlist/>
+        </property>
         <property name="bufferSize">
          <number>2500</number>
+        </property>
+        <property name="updatesAsynchronously">
+         <bool>true</bool>
         </property>
         <property name="timeSpan">
          <double>30.000000000000000</double>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
### #20
DeviceDisplay is now split into `TyphonDisplay` and `DeviceDisplay`. The base display instantiates all the widgets and panels but does not automatically enter anything. This preserves the feature set if someone wanted to make a `TyphonDisplay` without starting from an `ophyd.Device`. 
### #23
The `SignalPanel` how has an `add_pv` function. Most of the logic is included in this function. `add_signal` just rips the correct PV names from the given `EpicsSignal` and calls this function. This also means that PVs are stored as `(read_pv, write_pv)` instead of signals.

### #24
All tests use `using_fake_epics_pv`. This allows us to remove any need for checking if signals are connected inside the source code. 

### Miscellaneous
* Deprecated `prefix_label` 
* Deprecated `enum_attrs`, we will assume that we can connect to PVs when we make the display for now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #20
Closes #23
Closes #24

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests largely remained the same with the exception of those modified for #24, and a few deprecated calls

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings updated

<!--
## Screenshots (if appropriate):
-->
