### PR TITLE
Custom Device Buttons

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,13 @@
 ############
 import logging
 from functools import wraps
+
 ############
 # External #
 ############
 import pytest
 from pydm import PyDMApplication
+
 ###########
 # Package #
 ###########
@@ -24,6 +26,8 @@ def pytest_addoption(parser):
                      help="Set the level of the log")
     parser.addoption("--logfile", action="store", default=None,
                      help="Write the log output to specified file path")
+    parser.addoption("--dark", action="store_true", default=False,
+                     help="Use the dark stylesheet to display widgets")
     parser.addoption("--show", action="store_true", default=False,
                      help="Show the widgets produced by each test")
 
@@ -55,12 +59,15 @@ def _show_widgets(pytestconfig):
 
 
 @pytest.fixture(scope='session', autouse=True)
-def qapp():
+def qapp(pytestconfig):
     global application
     if application:
         pass
     else:
         application = PyDMApplication()
+        if pytestconfig.getoption('--dark'):
+            import qdarkstyle
+            application.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
     return application
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -14,7 +14,7 @@ from ophyd.tests.conftest import using_fake_epics_pv
 # Package #
 ###########
 from typhon.utils import clean_attr
-from typhon.display import DeviceDisplay
+from typhon.display import DeviceButton, DeviceDisplay
 from .conftest import show_widget
 
 
@@ -101,3 +101,13 @@ def test_display_with_hints(device):
     display = DeviceDisplay(device)
     assert len(display.ui.hint_plot.curves) == 1
     return display
+
+@using_fake_epics_pv
+@show_widget
+def test_device_button_init(device):
+    device.hints = {'fields' : [device.name + '_read1']}
+    button = DeviceButton(device)
+    assert button.ui.button_frame.layout().count() == 4
+    return button
+
+

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -14,7 +14,7 @@ from ophyd.tests.conftest import using_fake_epics_pv
 # Package #
 ###########
 from typhon.utils import clean_attr
-from typhon.display import DeviceButton, DeviceDisplay
+from typhon.display import DeviceDisplay
 from .conftest import show_widget
 
 
@@ -75,7 +75,7 @@ def test_display(device):
                 for sig in device.configuration_attrs])
     # We have all our subdevices
     sub_devices = [getattr(disp, 'device', None)
-                   for disp in display.ui.component_stack.children()]
+                   for disp in display.ui.component_widget.children()]
     assert all([getattr(device, dev) in sub_devices
                 for dev in device._sub_devices])
     return display
@@ -101,13 +101,3 @@ def test_display_with_hints(device):
     display = DeviceDisplay(device)
     assert len(display.ui.hint_plot.curves) == 1
     return display
-
-@using_fake_epics_pv
-@show_widget
-def test_device_button_init(device):
-    device.hints = {'fields' : [device.name + '_read1']}
-    button = DeviceButton(device)
-    assert button.ui.button_frame.layout().count() == 4
-    return button
-
-

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -19,7 +19,7 @@ kwargs = dict()
 @pytest.fixture(scope='module')
 def func_display():
     # Create mock function
-    def foo(first, second: float=3.14, hide: bool=True, third: bool=False):
+    def foo(first, second: float=3.14, hide: bool=True, third=False):
         kwargs.update({"first": first, "second": second,
                        "hide": hide, "third": third})
     # Create display

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,39 @@
+############
+# Standard #
+############
+
+############
+# External #
+############
+from ophyd.tests.conftest import using_fake_epics_pv
+
+###########
+# Package #
+###########
+from typhon.display import ComponentButton
+from .conftest import show_widget
+
+
+@using_fake_epics_pv
+@show_widget
+def test_component_button_add_pv():
+    button = ComponentButton("Test Device")
+    button.add_pv("Tst:Pv", "Test PV")
+    assert button.ui.button_frame.layout().count() == 4
+    return button
+
+
+@using_fake_epics_pv
+def test_component_button_checked():
+    button = ComponentButton("Test Device")
+    style = button.styleSheet()
+    # Check the button and watch the stylesheet change and the button register
+    # as checked
+    button.setChecked(True)
+    assert 'cyan' in button.styleSheet()
+    assert button.isChecked()
+    # Uncheck the button and make sure we are no longer checked and the
+    # stylesheet has returned to normal
+    button.setChecked(False)
+    assert not button.isChecked()
+    assert button.styleSheet() == style

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -11,7 +11,7 @@ from functools import partial
 ############
 from pydm.PyQt import uic
 from pydm.PyQt.QtCore import pyqtSlot, Qt
-from pydm.PyQt.QtGui import QGroupBox, QWidget, QHBoxLayout, QPushButton
+from pydm.PyQt.QtGui import QLabel, QGroupBox, QWidget, QHBoxLayout, QPushButton
 
 ###########
 # Package #
@@ -19,6 +19,7 @@ from pydm.PyQt.QtGui import QGroupBox, QWidget, QHBoxLayout, QPushButton
 from .func import FunctionPanel
 from .panel import SignalPanel
 from .utils import ui_dir, clean_attr, clean_source, channel_name
+from .widgets import TyphonLabel
 
 logger = logging.getLogger(__name__)
 
@@ -234,3 +235,31 @@ class DeviceDisplay(TyphonDisplay):
                                  field)
             except KeyError as exc:
                 logger.error("Unable to find PV name of %s", field)
+
+
+class DeviceButton(QWidget):
+    """
+    Button to display a subdevice
+
+    Parameters
+    ----------
+    """
+    def __init__(self, device, parent=None):
+        super().__init__(parent=parent)
+        self.device = device
+        self.device_description = self.device.describe()
+        # Instantiate UI
+        self.ui = uic.loadUi(os.path.join(ui_dir, 'button.ui'), self)
+        self.ui.name_label.setText(self.device.name)
+        button_layout = self.ui.button_frame.layout()
+        # Create hints
+        for field in getattr(self.device, 'hints', {}).get('fields', list()):
+            # Create label
+            label = QLabel(clean_attr(field))
+            label.setAlignment(Qt.AlignCenter)
+            # Create channel
+            sig_source = self.device_description[field]['source']
+            chan = channel_name(clean_source(sig_source))
+            widget = TyphonLabel(init_channel=chan)
+            button_layout.addWidget(label)
+            button_layout.addWidget(widget)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -11,7 +11,7 @@ from functools import partial
 ############
 from pydm.PyQt import uic
 from pydm.PyQt.QtCore import pyqtSlot, Qt
-from pydm.PyQt.QtGui import QLabel, QGroupBox, QWidget, QHBoxLayout, QPushButton
+from pydm.PyQt.QtGui import QWidget, QPushButton, QButtonGroup
 
 ###########
 # Package #
@@ -19,7 +19,7 @@ from pydm.PyQt.QtGui import QLabel, QGroupBox, QWidget, QHBoxLayout, QPushButton
 from .func import FunctionPanel
 from .panel import SignalPanel
 from .utils import ui_dir, clean_attr, clean_source, channel_name
-from .widgets import TyphonLabel
+from .widgets import ComponentButton
 
 logger = logging.getLogger(__name__)
 
@@ -60,25 +60,28 @@ class TyphonDisplay(QWidget):
         super().__init__(parent=parent)
         # Instantiate UI
         self.ui = uic.loadUi(os.path.join(ui_dir, 'base.ui'), self)
+        self.device_button_group = QButtonGroup()
+        self.device_button_group.addButton(self.ui.hide_button)
+        self.ui.hide_button.clicked.connect(self.hide_subdevices)
         # Set Label Names
         self.ui.name_label.setText(name)
         # Create Panels
-        self.sub_device_group = None
         self.method_panel = FunctionPanel(parent=self)
         self.read_panel = SignalPanel("Read", parent=self)
         self.config_panel = SignalPanel("Configuration", parent=self)
         self.misc_panel = SignalPanel("Miscellaneous", parent=self)
         # Add all the panels
-        self.ui.main_layout.addWidget(self.read_panel)
-        self.ui.main_layout.addWidget(self.method_panel)
-        self.ui.main_layout.addWidget(self.config_panel)
-        self.ui.main_layout.addWidget(self.misc_panel)
+        self.ui.main_layout.insertWidget(2, self.read_panel)
+        self.ui.main_layout.insertWidget(3, self.method_panel)
+        self.ui.main_layout.insertWidget(4, self.config_panel)
+        self.ui.main_layout.insertWidget(5, self.misc_panel)
         # Hide control of read_panel
         self.read_panel.hide_button.hide()
         # Hide widgets until signals are added to them
+        self.ui.buttons.hide()
         self.ui.component_widget.hide()
-        self.config_panel.show_contents(False)
-        self.misc_panel.show_contents(False)
+        self.config_panel.hide()
+        self.misc_panel.hide()
         self.method_panel.hide()
         self.ui.hint_plot.hide()
 
@@ -89,11 +92,13 @@ class TyphonDisplay(QWidget):
         """
         return self.method_panel.methods
 
-    def add_subdisplay(self, name, display):
+    def add_subdisplay(self, name, display, button=None):
         """
 
-        This creates another display for a subcomponent and a QPushButton that
-        will bring the display to the foreground
+        This add adisplay for a subcomponent and a QPushButton that
+        will bring the display to the foreground. Users can either specify
+        their button or have one generate for them. Either way the button is
+        connected to the the `pyqSlot` :meth:`.show_subdevice`
 
         Parameters
         ----------
@@ -102,21 +107,28 @@ class TyphonDisplay(QWidget):
 
         display : QWidget
             QWidget to associate with button
+
+        button : QWidget, optional
+            QWidget with the PyQtSignal ``clicked``. If None, is given a
+            QPushButton is created
         """
-        # Add our button layout if not created
-        if not self.sub_device_group:
-            logger.debug("Creating button layout for subdevices ...")
-            self.sub_device_group = QGroupBox("Component Devices")
-            self.sub_device_group.setLayout(QHBoxLayout())
-            self.ui.main_layout.insertWidget(1, self.sub_device_group)
-        # Create device display
-        idx = self.ui.component_stack.addWidget(display)
         # Create button
-        but = QPushButton()
-        but.setText(name)
-        self.sub_device_group.layout().addWidget(but)
+        if not button:
+            button = QPushButton(self)
+            button.setText(name)
+        # Add the button to the group
+        self.device_button_group.addButton(button)
+        # Add our button to the layout last in the line of buttons
+        # but above the spacer
+        idx = self.ui.buttons.layout().count() - 1
+        self.ui.buttons.layout().insertWidget(idx, button)
+        # Add our display to the widget
+        idx = self.ui.component_widget.addWidget(display)
         # Connect button
-        but.clicked.connect(partial(self.show_subdevice, idx=idx))
+        button.clicked.connect(partial(self.show_subdevice, idx=idx))
+        # Show the widgets if hidden
+        if self.ui.buttons.isHidden():
+            self.ui.buttons.show()
 
     def add_subdevice(self, device, methods=None):
         """
@@ -127,12 +139,22 @@ class TyphonDisplay(QWidget):
         device : ophyd.Device
 
         methods : list of callables, optional
-
         """
+        logger.debug("Creating button for %s", device.name)
+        # Create ComponentButton adding the hints automatically
+        button = ComponentButton(clean_attr(device.name), parent=self)
+        description = device.describe()
+        for field in getattr(device, 'hints', {}).get('fields', list()):
+            sig_source = description[field]['source']
+            button.add_pv(clean_source(sig_source), clean_attr(field))
+        # Create the actual subdisplay and add it to the component widget
+        # along with the button
         logger.debug("Creating subdisplay for %s", device.name)
-        self.add_subdisplay(device.name, DeviceDisplay(device,
-                                                       methods=methods,
-                                                       parent=self))
+        self.add_subdisplay(device.name,
+                            DeviceDisplay(device,
+                                          methods=methods,
+                                          parent=self),
+                            button=button)
 
     def add_pv_to_plot(self, pv, **kwargs):
         """
@@ -170,7 +192,17 @@ class TyphonDisplay(QWidget):
         if self.ui.component_widget.isHidden():
             self.ui.component_widget.show()
         # Show the correct subdevice widget
-        self.ui.component_stack.setCurrentIndex(idx)
+        self.ui.component_widget.setCurrentIndex(idx)
+
+    @pyqtSlot()
+    def hide_subdevices(self):
+        """
+        Hide the component widget and set all buttons unchecked
+        """
+        self.ui.component_widget.hide()
+        # Toggle the button off, each button can use its own pyqtSlot
+        for button in self.device_button_group.buttons():
+            button.toggled.emit(False)
 
 
 class DeviceDisplay(TyphonDisplay):
@@ -235,31 +267,6 @@ class DeviceDisplay(TyphonDisplay):
                                  field)
             except KeyError as exc:
                 logger.error("Unable to find PV name of %s", field)
-
-
-class DeviceButton(QWidget):
-    """
-    Button to display a subdevice
-
-    Parameters
-    ----------
-    """
-    def __init__(self, device, parent=None):
-        super().__init__(parent=parent)
-        self.device = device
-        self.device_description = self.device.describe()
-        # Instantiate UI
-        self.ui = uic.loadUi(os.path.join(ui_dir, 'button.ui'), self)
-        self.ui.name_label.setText(self.device.name)
-        button_layout = self.ui.button_frame.layout()
-        # Create hints
-        for field in getattr(self.device, 'hints', {}).get('fields', list()):
-            # Create label
-            label = QLabel(clean_attr(field))
-            label.setAlignment(Qt.AlignCenter)
-            # Create channel
-            sig_source = self.device_description[field]['source']
-            chan = channel_name(clean_source(sig_source))
-            widget = TyphonLabel(init_channel=chan)
-            button_layout.addWidget(label)
-            button_layout.addWidget(widget)
+        # Hide the lesser needed panels
+        self.config_panel.show_contents(False)
+        self.misc_panel.show_contents(False)

--- a/typhon/panel.py
+++ b/typhon/panel.py
@@ -50,6 +50,8 @@ class Panel(QWidget):
         # Create Widget Infrastructure
         self.title = title
         self.setLayout(QVBoxLayout())
+        self.layout().setContentsMargins(2, 2, 2, 2)
+        self.layout().setSpacing(5)
         # Create button control
         # Assuming widget is visible, set the button as checked
         self.contents = None
@@ -101,6 +103,7 @@ class SignalPanel(Panel):
         # Create empty panel contents
         self.contents = QWidget()
         self.contents.setLayout(QGridLayout())
+        self.contents.layout().setContentsMargins(2, 2, 2, 2)
         self.layout().addWidget(self.contents)
         # Add supplied signals
         if signals:

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>508</width>
+    <width>520</width>
     <height>599</height>
    </rect>
   </property>
@@ -23,7 +23,19 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetFixedSize</enum>
    </property>
-   <item>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item alignment="Qt::AlignTop">
     <widget class="QWidget" name="main_widget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -31,7 +43,10 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="main_layout" stretch="0,0">
+     <layout class="QVBoxLayout" name="main_layout" stretch="0,0,1">
+      <property name="spacing">
+       <number>5</number>
+      </property>
       <property name="sizeConstraint">
        <enum>QLayout::SetFixedSize</enum>
       </property>
@@ -44,7 +59,7 @@
          <enum>QFrame::Plain</enum>
         </property>
         <property name="lineWidth">
-         <number>2</number>
+         <number>3</number>
         </property>
         <property name="midLineWidth">
          <number>1</number>
@@ -67,7 +82,7 @@
           <widget class="QLabel" name="name_label">
            <property name="font">
             <font>
-             <pointsize>18</pointsize>
+             <pointsize>20</pointsize>
              <weight>75</weight>
              <bold>true</bold>
             </font>
@@ -130,7 +145,7 @@
          <stringlist/>
         </property>
         <property name="bufferSize">
-         <number>2500</number>
+         <number>60</number>
         </property>
         <property name="updatesAsynchronously">
          <bool>true</bool>
@@ -143,23 +158,57 @@
         </property>
        </widget>
       </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QWidget" name="component_widget" native="true">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+   <item alignment="Qt::AlignTop">
+    <widget class="QFrame" name="buttons">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
        <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
+       <verstretch>2</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>2</number>
+     </property>
+     <property name="midLineWidth">
+      <number>0</number>
+     </property>
+     <layout class="QVBoxLayout" name="button_layout">
       <property name="sizeConstraint">
-       <enum>QLayout::SetFixedSize</enum>
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <property name="leftMargin">
+       <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>2</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
       </property>
       <item>
        <widget class="QPushButton" name="hide_button">
@@ -178,21 +227,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QStackedWidget" name="component_stack">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="page"/>
-        <widget class="QWidget" name="page_2"/>
-       </widget>
-      </item>
-      <item>
        <spacer name="verticalSpacer_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -208,9 +242,22 @@
      </layout>
     </widget>
    </item>
+   <item alignment="Qt::AlignTop">
+    <widget class="QStackedWidget" name="component_widget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page"/>
+     <widget class="QWidget" name="page_2"/>
+    </widget>
+   </item>
   </layout>
-  <zorder>component_widget</zorder>
-  <zorder>main_widget</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -220,22 +267,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>hide_button</sender>
-   <signal>clicked()</signal>
-   <receiver>component_widget</receiver>
-   <slot>hide()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>353</x>
-     <y>27</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>425</x>
-     <y>180</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/typhon/ui/button.ui
+++ b/typhon/ui/button.ui
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>201</width>
+    <height>161</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="button_frame">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>3</number>
+     </property>
+     <layout class="QVBoxLayout" name="layout">
+      <property name="spacing">
+       <number>3</number>
+      </property>
+      <property name="sizeConstraint">
+       <enum>QLayout::SetFixedSize</enum>
+      </property>
+      <property name="leftMargin">
+       <number>5</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="name_label">
+        <property name="font">
+         <font>
+          <pointsize>18</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Name</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -1,16 +1,20 @@
 ############
 # Standard #
 ############
+import os.path
 
 ############
 # External #
 ############
+from pydm.PyQt import uic
 from pydm.PyQt.QtCore import QSize, Qt
+from pydm.PyQt.QtGui import QLabel, QAbstractButton
 from pydm.widgets import PyDMLabel, PyDMEnumComboBox
 
 ###########
 # Package #
 ###########
+from .utils import ui_dir, channel_name
 
 
 class TyphonComboBox(PyDMEnumComboBox):
@@ -33,3 +37,71 @@ class TyphonLabel(PyDMLabel):
     def sizeHint(self):
         # This is to match the PyDMLineEdit sizeHint
         return QSize(100, 30)
+
+
+class ComponentButton(QAbstractButton):
+    """
+    Button to display a Component
+
+    Displays the name given along with a layout that you can add PVs.The
+    ComponentButton is used by :func:`.TyphonDisplay.add_subdevice`.
+
+    Parameters
+    ----------
+    name : str
+        Name displayed on button
+
+    parent : QWidget, optional
+    """
+    def __init__(self, name, parent=None):
+        # Basic widget setup
+        super().__init__(parent=parent)
+        self.setCheckable(True)
+        # Instantiate UI
+        self.ui = uic.loadUi(os.path.join(ui_dir, 'button.ui'), self)
+        self.ui.name_label.setText(name)
+        self.toggled.connect(self.setChecked)
+        # Store orignal stylesheet
+        self.fixed_style = self.styleSheet()
+
+    def add_pv(self, pv, name):
+        """
+        Add a PV to the ComponentButton
+
+        Parameters
+        ----------
+        pv : str
+            Name of PV to add to the button
+        """
+        # Create label
+        label = QLabel(name)
+        label.setAlignment(Qt.AlignCenter)
+        # Create PyDMLabel and add everything to layout
+        widget = TyphonLabel(init_channel=channel_name(pv))
+        self.ui.button_frame.layout().addWidget(label)
+        self.ui.button_frame.layout().addWidget(widget)
+
+    def paintEvent(self, evt):
+        """
+        Reimplement paintEvent to hide `NotImplementedError`
+        """
+        pass
+
+    def setChecked(self, checked):
+        """
+        Change the border of the ComponentButton when checked
+
+        Calls `QAbstractButton.setChecked` underneath to manage button state.
+
+        Parameters
+        ----------
+        checked : bool
+            Whether to set the ComponentButton checked or unchecked.
+        """
+        # Change stylesheet
+        if checked:
+            self.setStyleSheet("QFrame {border-color : cyan}")
+        else:
+            self.setStyleSheet(self.fixed_style)
+        # Register with QAbstractButton
+        super().setChecked(checked)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Instead of simple QPushButtons to switch between devices, we now have `ComponentButton`. These are placed in a vertical layout to the right of the main device display and function the same as prior QPushButtons did.

If you use `add_subdevice`, the `ComponentButton` will automatically be creating with the `hints` of the device. Otherwise the `ComponentButton` can have  PVs manually added via the function `add_pv`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #19 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test for ComponentButton in `tests/test_widgets`


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated docstrings

## Screenshots:

<img width="514" alt="screen shot 2017-11-30 at 8 42 26 pm" src="https://user-images.githubusercontent.com/25753048/33469208-40c2e514-d616-11e7-8998-1d78ec8b71df.png">
