### PR TITLE
CI: Installation via Conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ after_success:
       anaconda upload bld-dir/linux-64/*.tar.bz2
     fi
   - |
-    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $BUILD ]]; then
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $BUILD ]]; then
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
       anaconda upload bld-dir/linux-64/*.tar.bz2
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ env:
 matrix:
   include:
      - python: 3.6
-       env: BUILD_DOCS=1
+       env:
+          - BUILD_DOCS=1
+          - PYDM_CHANNEL=pydm-tag
+     - python: 3.6
+       env: PYDM_CHANNEL=pydm-dev
 
 services:
   - docker
@@ -40,19 +44,19 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install conda-build anaconda-client
-  - conda update -q conda
+  - conda update -q conda conda-build
+  - conda config --append channels $PYDM_CHANNEL 
+  - conda config --append channels lightsource2-tag
+  - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
-  #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig coverage pydm pip ophyd pyqt=5 pytest -c lightsource2-tag -c pydm-dev -c conda-forge -c gsecars
-  #Launch Conda environment
+  # Grab all dependencies
+  - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
+  - conda config --add channels "file://`pwd`/bld-dir"
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION typhon --file dev-requirements.txt
+  # Launch Conda environment
   - source activate test-environment
-  - pip install codecov
-  - pip install -r requirements.txt
-  - pip install -r dev-requirements.txt
-  #Install
-  - python setup.py install
-  #Setup some path environment variables for epics
+  # Setup some path environment variables for epics
   - export PATH=$PATH:$EPICS_BASE/bin/$EPICS_HOST_ARCH
   - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$EPICS_BASE/lib/$EPICS_HOST_ARCH"
   - echo "PATH=$PATH"
@@ -71,8 +75,6 @@ script:
   - set -e
   - |
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD_DOCS ]]; then
-      # Install doctr 
-      pip install doctr
       # Create HTML documentation  
       pushd docs
       sphinx-autogen -o source/generated source/*.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
      - python: 3.6
        env:
-          - BUILD_DOCS=1
+          - BUILD=1
           - PYDM_CHANNEL=pydm-tag
      - python: 3.6
        env: PYDM_CHANNEL=pydm-dev
@@ -74,7 +74,7 @@ script:
   # Build docs
   - set -e
   - |
-    if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD_DOCS ]]; then
+    if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD ]]; then
       # Create HTML documentation  
       pushd docs
       sphinx-autogen -o source/generated source/*.rst
@@ -86,3 +86,13 @@ script:
 
 after_success:
   - codecov
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $BUILD ]]; then
+      export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
+      anaconda upload bld-dir/linux-64/*.tar.bz2
+    fi
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $BUILD ]]; then
+      export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
+      anaconda upload bld-dir/linux-64/*.tar.bz2
+    fi

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ defaults of the representative Python class, these signals are sorted into
 different categories based on their relevance to operators. Typhon uses this
 information to craft user interfaces.
 
+## Installation
+Recommended installation:
+```
+conda install typhon -c pcds-tag -c pydm-tag -c lightsource2-tag -c conda-forge
+```
+All `-tag` channels have `-dev` counterparts for bleeding edge installations.
+Both `requirements.txt` and optional `dev-requirements.txt` are kept up to date
+as well for those who prefer installation via `pip`
+
 ## Related Projects
 [**PyDM**](https://github.com/slaclab/pydm) - PyQT Display Manager for EPICS information
 

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,30 @@
+{% set data = load_setup_py_data() %}
+
+package:
+    name    : typhon
+    version : {{ data.get('version') }}
+
+source:
+    path: ..
+
+requirements:
+    build:
+      - python
+
+
+    run:
+      - python
+      - pydm
+      - ophyd
+
+test:
+    imports:
+      - typhon
+
+    requires: 
+      - pytest
+
+about:
+  home: https://github.com/pcdshub/typhon
+  license: SLAC Open License
+  summary: Automatic User Interface Creation from Ophyd Devices

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
 pytest
+codecov
 matplotlib
 ipython
 flake8
 sphinx
 sphinx_rtd_theme
+doctr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When I tagged Typhon `v0.1.0` we did not have a dedicated Conda channel for the PCDS group so I didn't bother making a recipe. We now have `pcds-tag` and `pcds-dev` so this PR builds Typhon and deploys to the appropriate channel.

Also since creating the repository @ZLLentz laid out a way to do the Travis installation entirely via Conda. I think this is a more useful testing strategy as:
1) Most users will install via the Conda route
2) In prior iterations we would test and evaluate pull requests based on the `pip` install then only when the PR was merged would we see that the conda-recipe was invalid and the build would fail.

Finally, I added a build to the matrix that tests with `pydm-dev` instead of the tagged builds. This will allow us to use new features that haven't yet been tagged by the `PyDM` team, as well as give them some useful feedback if they break something unexpected.

### Side Note
 I kind of want to host a PyDM build on the `pcds-*` channels. It is slightly annoying to have a Conda channel to just include a single package. We as a group will also want to host a `pyepics` install so the nice thing is it would then avoid `gsecars`...

