### PR TITLE
ENH: SignalPlugin

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,3 +47,4 @@ Related Projects
 
    display.rst
    widgets.rst
+   plugins.rst

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,0 +1,10 @@
+==============
+Custom Plugins
+==============
+Available Typhon specific plugins:
+
+.. autosummary::
+    :toctree: generated
+
+    typhon.plugins.ClassConnection
+    typhon.plugins.SignalConnection

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -68,3 +68,9 @@ def test_signal_connection(qapp):
     widget.send_value_signal.emit(1)
     qapp.processEvents()
     assert sig.get() == 3
+
+
+def test_plugin_loading(qapp):
+    print(qapp.plugins)
+    assert qapp.plugins['sig'] == SignalConnection
+    assert qapp.plugins['obj'] == SignalConnection

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -13,7 +13,7 @@ from pydm.PyQt.QtGui import QWidget
 ##########
 # Module #
 ##########
-from typhon.plugins import SignalConnection, ClassConnection
+from typhon.plugins import SignalPlugin, SignalConnection, ClassConnection
 from typhon.plugins.core import obj_from_string
 
 class WritableWidget(QWidget, PyDMWritableWidget):
@@ -71,6 +71,4 @@ def test_signal_connection(qapp):
 
 
 def test_plugin_loading(qapp):
-    print(qapp.plugins)
-    assert qapp.plugins['sig'] == SignalConnection
-    assert qapp.plugins['obj'] == SignalConnection
+    assert isinstance(qapp.plugins['sig'], SignalPlugin)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,29 @@
+############
+# Standard #
+############
+import sys
+###############
+# Third Party #
+###############
+
+
+##########
+# Module #
+##########
+from typhon.plugins import ClassConnection
+
+
+def test_class_connection():
+    # Create a basic object
+    address = 'ophyd.Device|Tst:Motor:1|name=Test Motor'
+    cc = ClassConnection(address, address)
+    assert cc.obj.prefix == 'Tst:Motor:1'
+    assert cc.obj.name == 'Test Motor'
+    # Create an arg-less example, must be imported example
+    sys.modules.pop('io')
+    address = 'io.StringIO|random text'
+    cc_arg_less = ClassConnection(address, address)
+    assert cc_arg_less.obj.read() == 'random text'
+    # Check we do not create a new device where not requested
+    cc_in = ClassConnection.from_object(cc.obj)
+    assert id(cc_in.obj) == id(cc.obj)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -14,11 +14,16 @@ from pydm.PyQt.QtGui import QWidget
 # Module #
 ##########
 from typhon.plugins import SignalConnection, ClassConnection
-
+from typhon.plugins.core import obj_from_string
 
 class WritableWidget(QWidget, PyDMWritableWidget):
     """Simple Testing Widget"""
     pass
+
+
+def test_obj_from_string():
+    obj = obj_from_string('io.StringIO', 'random text')
+    assert obj.read() == 'random text'
 
 
 def test_class_connection():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,15 +2,23 @@
 # Standard #
 ############
 import sys
+
 ###############
 # Third Party #
 ###############
-
+import ophyd
+from pydm.widgets.base import PyDMWritableWidget
+from pydm.PyQt.QtGui import QWidget
 
 ##########
 # Module #
 ##########
-from typhon.plugins import ClassConnection
+from typhon.plugins import SignalConnection, ClassConnection
+
+
+class WritableWidget(QWidget, PyDMWritableWidget):
+    """Simple Testing Widget"""
+    pass
 
 
 def test_class_connection():
@@ -27,3 +35,31 @@ def test_class_connection():
     # Check we do not create a new device where not requested
     cc_in = ClassConnection.from_object(cc.obj)
     assert id(cc_in.obj) == id(cc.obj)
+
+
+def test_signal_connection(qapp):
+    # Create a signal and attach our listener
+    sig = ophyd.Signal(name='my_signal', value=1)
+    widget = WritableWidget()
+    listener = widget.channels()[0]
+    sig_conn = SignalConnection.from_object(sig)
+    sig_conn.add_listener(listener)
+    # Check that our widget receives the initial value
+    qapp.processEvents()
+    assert widget.value == 1
+    # Check that we can push values back to the signal which in turn causes the
+    # internal value at the widget to update
+    widget.send_value_signal.emit(2)
+    qapp.processEvents()
+    qapp.processEvents()  # Must be called twice. Multiple rounds of signals
+    assert sig.get() == 2
+    assert widget.value == 2
+    sig_conn.remove_listener(listener)
+    # Check that our signal is disconnected completely and maintains the same
+    # value as the signal updates in the background
+    sig.put(3)
+    qapp.processEvents()
+    assert widget.value == 2
+    widget.send_value_signal.emit(1)
+    qapp.processEvents()
+    assert sig.get() == 3

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,6 +1,10 @@
 __all__ = ['TyphonDisplay', 'DeviceDisplay', 'ComponentButton']
+from .plugins import SignalPlugin
 from .display import TyphonDisplay, DeviceDisplay
 from .widgets import ComponentButton
+from pydm.data_plugins import add_plugin
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+add_plugin(SignalPlugin)

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ['ClassConnection']
+from .core import ClassConnection

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ['ClassConnection']
-from .core import ClassConnection
+__all__ = ['ClassConnection', 'SignalConnection']
+from .core import SignalConnection, ClassConnection

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,2 +1,3 @@
-__all__ = ['ClassConnection', 'SignalConnection']
-from .core import SignalConnection, ClassConnection
+__all__ = ['ClassConnection', 'SignalConnection',
+           'ClassPlugin', 'SignalPlugin']
+from .core import SignalConnection, ClassConnection, SignalPlugin, ClassPlugin

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -32,8 +32,8 @@ class ClassConnection(PyDMConnection):
     -------
     .. code:: python
 
-        conn = ClassConnection(cls://ophyd.EpicsMotor|'Tst:Mtr:07'|name=Test,
-                               ophyd.EpicsMotor|'Tst:Mtr:07'|name=Test)
+        conn = ClassConnection("cls://ophyd.EpicsMotor|'Tst:Mtr:07'|name=Test",
+                               "ophyd.EpicsMotor|'Tst:Mtr:07'|name=Test")
 
     Notes
     -----

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -1,0 +1,98 @@
+############
+# Standard #
+############
+import sys
+import logging
+import importlib
+
+###############
+# Third Party #
+###############
+from pydm.data_plugins.plugin import PyDMConnection
+
+##########
+# Module #
+##########
+
+logger = logging.getLogger(__name__)
+
+
+class ClassConnection(PyDMConnection):
+    """
+    Connection which spawns an object of specified class
+
+    Attributes
+    ----------
+    obj: object
+        The created object is stored on the connection for use by subclasses
+
+    Example
+    -------
+    .. code:: python
+
+        conn = ClassConnection(cls://ophyd.EpicsMotor|'Tst:Mtr:07'|name=Test,
+                               ophyd.EpicsMotor|'Tst:Mtr:07'|name=Test)
+
+    Notes
+    -----
+    "preassembled" provides a shortcut instead of creating a new object. This
+    is useful if channel connections are being scripted programatically as
+    opposed to from the Designer. The channel and address arguments are
+    completely ignored in this case.
+    """
+    def __init__(self, channel, address, protocol=None,
+                 parent=None, preassembled=None):
+        # Base initialization
+        super().__init__(channel, address, protocol=protocol, parent=parent)
+        # Just use the preassambled object if given to us
+        # Otherwise, instantiate our own
+        logger.debug("Creating connection to %s", address)
+        if preassembled:
+            logger.debug("Using an already instantiated object as reference")
+            self.obj = preassembled
+        else:
+            # NOTE: This was taken entirely from happi/loader.py. The reason it
+            # was not directly imported was to avoid an unneeded dependency
+
+            # Parse the classname, arguments and keywords from the address
+            # First assume the form {class}|{args}|{kwargs}
+            try:
+                cls, args, kwargs = address.split('|', 2)
+            # Keyword arguments are optional i.e {class}|{args}
+            except ValueError:
+                cls, args = address.split('|', 1)
+                kwargs = None
+            # Import the class
+            mod, cls = cls.rsplit('.', 1)
+            if mod in sys.modules:
+                mod = sys.modules[mod]
+            else:
+                logger.debug("Importing %s", mod)
+                mod = importlib.import_module(mod)
+            # Grab our device
+            cls = getattr(mod, cls)
+            # Format arguments
+            if args:
+                args = args.split(',')
+            else:
+                args = list()
+            # Format keywords
+            if kwargs:
+                kwargs = dict([pair.split('=', 1)
+                               for pair in kwargs.split(',')])
+            else:
+                kwargs = dict()
+            # Create our object
+            logger.debug("Instantiating %s ...", cls.__name__)
+            self.obj = cls(*args, **kwargs)
+
+    @classmethod
+    def from_object(cls, obj):
+        """
+        Create a Connection object with an already instantiated object
+
+        Parameters
+        ----------
+        obj : object
+        """
+        return cls(None, None, preassembled=obj)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -117,8 +117,8 @@ class SignalConnection(ClassConnection):
     -------
     .. code:: python
 
-        conn = ClassConnection(sig://ophyd.Signal|name=Test,)
-                               ophyd.Signal|name=Test)
+        conn = ClassConnection('sig://ophyd.Signal|name=Test',)
+                               'ophyd.Signal|name=Test')
     """
     supported_types = [int, float, str, np.ndarray]
 

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -9,7 +9,7 @@ import importlib
 # Third Party #
 ###############
 import numpy as np
-from pydm.data_plugins.plugin import PyDMConnection
+from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from pydm.PyQt.QtCore import pyqtSlot, Qt
 
 ##########
@@ -223,3 +223,16 @@ class SignalConnection(ClassConnection):
                                  "for type %s", channel.address, _typ)
         # Disconnect any other signals
         super().remove_listener(channel)
+
+
+class ClassPlugin(PyDMPlugin):
+    """Plugin for generic Python objects"""
+    protocol = 'obj'
+    connection_class = ClassConnection
+
+
+class SignalPlugin(PyDMPlugin):
+    """Plugin for Ophyd Signal objects"""
+    protocol = 'sig'
+    connection_class = SignalConnection
+

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -143,7 +143,7 @@ class SignalConnection(ClassConnection):
         try:
             self.obj.put(new_val)
         except Exception as exc:
-            logger.exception("Unable to put %s to %s", new_val, self.obj.name)
+            logger.exception("Unable to put %r to %s", new_val, self.obj.name)
 
     def send_new_value(self, value=None, **kwargs):
         """
@@ -193,6 +193,6 @@ class SignalConnection(ClassConnection):
                     channel.value_signal[_typ].disconnect(self.put_value)
                 except KeyError:
                     logger.debug("Unable to disconnect value_signal from %s "
-                                 "for type", channel.address, _typ)
+                                 "for type %s", channel.address, _typ)
         # Disconnect any other signals
         super().remove_listener(channel)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -110,6 +110,9 @@ class ClassConnection(PyDMConnection):
             # Create our object
             logger.debug("Instantiating %s ...", cls)
             self.obj = obj_from_string(cls, args, kwargs)
+        # Report the object as accessible and connected
+        self.write_access_signal.emit(True)
+        self.connection_state_signal.emit(True)
 
     @classmethod
     def from_object(cls, obj):

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -235,4 +235,3 @@ class SignalPlugin(PyDMPlugin):
     """Plugin for Ophyd Signal objects"""
     protocol = 'sig'
     connection_class = SignalConnection
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Included are two custom `Plugin` types.
* `ClassPlugin` a generic way to load arbitrary objects with an address. This won't be called directly but stores the common initialization that is done by `SignalPlugin` and will eventually be done by `TyphonPlugin` and `HappiPlugin`.
* `SignalPlugin` subscribes to any Ophyd Signal and sends updates to the listening channels. It also allows writes back to the signal itself.

I don't imagine either of these plugins will be used in screens themselves. I therefore didn't make the actual `PyDMConnection` objects. The shenanigans of correctly typing `args` and `kwargs` from the address doesn't seem like a road we should go down. `TyphonPlugin` will just inspect the Ophyd object and create the signals using the `from_object` classmethod.

### Outstanding Questions
* There is not a good way to tell if a `Signal` can be written to. We are forced to `try / except`
* We can expect all `Signal` objects to have a `connected` attribute. Should we send this information back through the channel?
* `Signal.set` or `Signal.put`?


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #44 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Instantiation of a `ClassConnection` object
* Connect and disconnect a `SignalPlugin`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Short table of Plugin information