### PR TITLE
RunEngine Widget

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+bluesky
 pytest
 codecov
 matplotlib

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,46 @@
+############
+# Standard #
+############
+
+############
+# External #
+############
+import pytest
+from bluesky.plan_stubs import pause, open_run, close_run, sleep
+
+###########
+# Package #
+###########
+from .conftest import show_widget
+from typhon.engine import EngineWidget
+
+
+def plan():
+    yield from open_run()
+    yield from sleep(1)
+    yield from pause()
+    yield from close_run()
+
+
+def test_engine_state_changes():
+    ew = EngineWidget()
+    assert ew.label.text() == 'Idle'
+    assert len(ew.control) == len(ew.control.available_commands['idle']) + 1
+    ew.on_state_change('running', 'idle')
+    assert ew.label.text() == 'Running'
+    assert len(ew.control) == len(ew.control.available_commands['running']) + 1
+    ew.on_state_change('paused', 'running')
+    assert ew.label.text() == 'Paused'
+    assert len(ew.control) == len(ew.control.available_commands['paused']) + 1
+
+
+@show_widget
+def test_engine_plan_execution():
+    # Create a widget and load plans
+    ew = EngineWidget()
+    ew.plan = lambda: plan()
+    ew.control.currentIndexChanged['QString'].emit('Start')
+    assert ew.engine.state == 'paused'
+    ew.control.currentIndexChanged['QString'].emit('Resume')
+    assert ew.engine.state == 'idle'
+    return ew

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,18 +1,21 @@
 ############
 # Standard #
 ############
+import time
 
 ############
 # External #
 ############
 import pytest
 from bluesky.plan_stubs import pause, open_run, close_run, sleep
+from bluesky.utils import RunEngineInterrupted
+from pydm.PyQt.QtCore import pyqtSlot, QObject
 
 ###########
 # Package #
 ###########
 from .conftest import show_widget
-from typhon.engine import EngineWidget
+from typhon.engine import QRunEngine, EngineWidget
 
 
 def plan():
@@ -22,25 +25,70 @@ def plan():
     yield from close_run()
 
 
-def test_engine_state_changes():
+class QRecorder(QObject):
+    """Helper object to record state change signals"""
+    def __init__(self):
+        super().__init__()
+        self.state_changes = list()
+
+    @pyqtSlot('QString', 'QString')
+    def on_state_change(self, new, old):
+        """Record all state changes"""
+        self.state_changes.append((new, old))
+
+
+def test_qrunengine_signals(qapp):
+    # Create our Engine and recorder and connect the signal
+    QRE = QRunEngine()
+    qrec = QRecorder()
+    QRE.state_changed.connect(qrec.on_state_change)
+    # Run the plan until it pauses automatically
+    try:
+        QRE(plan())
+    except RunEngineInterrupted:
+        pass
+    # Process our first round of events
+    qapp.processEvents()
+    assert qrec.state_changes[0] == ('running', 'idle')
+    assert qrec.state_changes[1] == ('paused', 'running')
+    QRE.resume()
+    # Process our second round of events
+    qapp.processEvents()
+    assert qrec.state_changes[2] == ('running', 'paused')
+    assert qrec.state_changes[3] == ('idle', 'running')
+
+
+def test_engine_readback_state_changes(qapp):
     ew = EngineWidget()
+    ew.engine.on_state_change('idle', 'running')
+    qapp.processEvents()
     assert ew.label.text() == 'Idle'
-    assert len(ew.control) == len(ew.control.available_commands['idle']) + 1
-    ew.on_state_change('running', 'idle')
+    assert ew.control.currentWidget().text() == 'Start'
+    ew.engine.on_state_change('running', 'idle')
+    qapp.processEvents()
+    assert ew.control.currentWidget().text() == 'Pause'
     assert ew.label.text() == 'Running'
-    assert len(ew.control) == len(ew.control.available_commands['running']) + 1
-    ew.on_state_change('paused', 'running')
+    ew.engine.on_state_change('paused', 'running')
+    qapp.processEvents()
     assert ew.label.text() == 'Paused'
-    assert len(ew.control) == len(ew.control.available_commands['paused']) + 1
+    assert len(ew.control.currentWidget()) == len(ew.control.pause_commands)
 
 
 @show_widget
-def test_engine_plan_execution():
+def test_engine_plan_execution(qapp):
     # Create a widget and load plans
     ew = EngineWidget()
-    ew.plan = lambda: plan()
-    ew.control.currentIndexChanged['QString'].emit('Start')
+    # Create a plan
+    ew.engine.plan_creator = lambda: plan()
+    assert ew.engine.state == 'idle'
+    # Start the RunEngine
+    ew.control.state_widgets['idle'].clicked.emit()
+    qapp.processEvents()
+    time.sleep(1.0)
     assert ew.engine.state == 'paused'
-    ew.control.currentIndexChanged['QString'].emit('Resume')
+    # Resume after a pause
+    ew.control.currentWidget().activated['QString'].emit('Resume')
+    qapp.processEvents()
+    time.sleep(0.5)
     assert ew.engine.state == 'idle'
     return ew

--- a/typhon/engine.py
+++ b/typhon/engine.py
@@ -86,7 +86,7 @@ class QRunEngine(QObject, RunEngine):
         # Load the function from registry
         try:
             func = self.command_registry[command]
-        # Catch commands that we have no idea how to obey 
+        # Catch commands that we have no idea how to obey
         except KeyError as exc:
             logger.exception('Unrecognized command for RunEngine -> %s',
                              exc)
@@ -120,11 +120,11 @@ class EngineLabel(QLabel):
         color = self.color_map[state]
         self.setStyleSheet('QLabel {background-color: %s}' % color)
 
-
     def connect(self, engine):
         """Connect an existing QRunEngine"""
         engine.state_changed.connect(self.on_state_change)
         self.on_state_change(engine.state, None)
+
 
 class EngineControl(QStackedWidget):
     """

--- a/typhon/engine.py
+++ b/typhon/engine.py
@@ -1,0 +1,226 @@
+############
+# Standard #
+############
+import logging
+
+
+############
+# External #
+############
+from bluesky import RunEngine
+from bluesky.utils import RunEngineInterrupted, install_qt_kicker
+from pydm.PyQt.QtGui import QVBoxLayout, QLabel, QComboBox, QGroupBox
+from pydm.PyQt.QtCore import pyqtSignal, pyqtSlot
+
+
+logger = logging.getLogger(__name__)
+
+
+def no_plan_warning(*args, **kwargs):
+    """
+    Convienence function to raise a user warning
+    """
+    logger.critical("Attempting to use the RunEngine "
+                    "without configuring a plan")
+
+
+class EngineLabel(QLabel):
+    """
+    QLabel to display the RunEngine Status
+
+    Attributes
+    ----------
+    color_map : dict
+        Mapping of Engine states to color displays
+    """
+    color_map = {'running': 'green',
+                 'paused': 'yellow',
+                 'idle': 'red'}
+
+    @pyqtSlot('QString', 'QString')
+    def on_state_change(self, state, old_state):
+        """Update the display Engine"""
+        # Update the label
+        self.setText(state.capitalize())
+        # Update the background color
+        color = self.color_map[state]
+        self.setStyleSheet('QLabel {background-color: %s}' % color)
+
+
+class EngineControl(QComboBox):
+    """
+    RunEngine through a QComboBox
+
+    Listens to the state of the RunEngine and shows the available commands for
+    the current state.
+
+    Attributes
+    ----------
+    null_command : str
+        Display value for the empty command
+
+    available_commands: dict
+        Mapping of state to available RunEngine commands
+    """
+    null_command = '-'
+    available_commands = {'running': ['Halt', 'Pause'],
+                          'idle': ['Start'],
+                          'paused': ['Abort', 'Halt',  'Resume', 'Stop']}
+
+    @pyqtSlot('QString', 'QString')
+    def on_state_change(self, state, old_state):
+        # Clear old commands
+        self.clear()
+        # Find the list of available commands
+        self.addItems([self.null_command] + self.available_commands[state])
+
+
+class EngineWidget(QGroupBox):
+    """
+    RunEngine Control Widget
+
+    Parameters
+    ----------
+    engine : RunEngine, optional
+        The underlying RunEngine object. A basic version wil be instatiated if
+        one is not provided
+
+    plan : callable, optional
+        A callable  that takes no parameters and returns a generator. If the
+        plan is meant to be called repeatedly the function should make sure
+        that a refreshed generator is returned each time
+
+    Attributes
+    ----------
+    engine_state_change : pyqtSignal('QString', 'QString')
+        Signal emitted by changes in the RunEngine state. The first string is
+        the current state, the second is the previous state
+
+    update_rate: float
+        Update rate the qt_kicker is installed at
+
+    command_registry: dict
+        Mapping of commands received by the pyqtSlot `command` and actual
+        Python callables
+    """
+    engine_state_change = pyqtSignal('QString', 'QString')
+    update_rate = 0.02
+    command_registry = {'Halt': RunEngine.halt,
+                        'Start': no_plan_warning,
+                        'Abort': RunEngine.abort,
+                        'Resume': RunEngine.resume,
+                        'Pause': RunEngine.request_pause,
+                        'Stop': RunEngine.stop}
+
+    def __init__(self, engine=None, plan=None, parent=None):
+        # Instantiate widget information and layout
+        super().__init__('Engine Control', parent=parent)
+        self.setStyleSheet('QLabel {qproperty-alignment: AlignCenter}')
+        self.label = EngineLabel(parent=self)
+        self.command_label = QLabel('Available Commands')
+        self.status_label = QLabel('Engine Status')
+        self.control = EngineControl()
+        lay = QVBoxLayout()
+        lay.addWidget(self.status_label)
+        lay.addWidget(self.label)
+        lay.addWidget(self.command_label)
+        lay.addWidget(self.control)
+        self.setLayout(lay)
+        # Create a new RunEngine if we were not provided one
+        self._engine = None
+        self._plan = None
+        self.engine = engine or RunEngine()
+
+    @property
+    def plan(self):
+        """
+        Stored plan callable
+        """
+        return self._plan
+
+    @plan.setter
+    def plan(self, plan):
+        logger.debug("Storing a new plan for the RunEngine")
+        # Do not allow plans to be set while RunEngine is active
+        if self.engine and self.engine.state != 'idle':
+            logger.exception("Can not change the configured plan while the "
+                             "RunEngine is running!")
+            return
+        # Store our plan internally
+        self._plan = plan
+        # Register a new call command
+        self.command_registry['Start'] = (lambda x:
+                                          RunEngine.__call__(x, self.plan()))
+
+    @property
+    def engine(self):
+        """
+        Underlying RunEngine object
+        """
+        return self._engine
+
+    @engine.setter
+    def engine(self, engine):
+        logger.debug("Storing a new RunEngine object")
+        # Do not allow engine to be swapped while RunEngine is active
+        if self._engine and self._engine.state != 'idle':
+            raise RuntimeError("Can not change the RunEngine while the "
+                               "RunEngine is running!")
+        # Create a kicker, not worried about doing this multiple times as this
+        # is checked by `install_qt_kicker` itself
+        install_qt_kicker(update_rate=self.update_rate)
+        engine.state_hook = self.on_state_change
+        # Connect signals
+        self._engine = engine
+        self.engine_state_change.connect(self.label.on_state_change)
+        self.engine_state_change.connect(self.control.on_state_change)
+        self.control.currentIndexChanged['QString'].connect(self.command)
+        # Run callbacks manually to initialize widgets. We can not emit the
+        # signal specifically because we can not emit signals in __init__
+        state = self._engine.state
+        self.label.on_state_change(state, None)
+        self.control.on_state_change(state, None)
+
+    def on_state_change(self, state, old_state):
+        """
+        Report a state change of the RunEngine
+
+        This is added directly to the `RunEngine.state_hook` and emits the
+        `engine_state_change` signal.
+
+        Parameters
+        ----------
+        state: str
+
+        old_state: str
+
+        """
+        self.engine_state_change.emit(state, old_state)
+
+    @pyqtSlot('QString')
+    def command(self, command):
+        """
+        Accepts commands and instructs the RunEngine accordingly
+
+        Parameters
+        ----------
+        command : str
+            Name of the command in the :attr:`.command_registry:`
+        """
+        # Ignore null commands
+        if not command or command == self.control.null_command:
+            return
+        logger.info("Requested command %s for RunEngine", command)
+        # Load thefunction from registry
+        try:
+            func = self.command_registry[command]
+        except KeyError as exc:
+            logger.exception('Unrecognized command for RunEngine -> %s',
+                             exc)
+            return
+        # Execute our loaded function
+        try:
+            func(self.engine)
+        # Pausing raises an exception
+        except RunEngineInterrupted as exc:
+            logger.debug("RunEngine paused")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Basic Widget level control of the RunEngine. This includes:

* A colored label that indicates the current state of the Engine
* A dropdown QComboBox that presents the acceptable actions for the current engine state.
* All performed with signals and slots so other widgets can connect to RunEngine information without writing custom Python code.

### Remaining Questions
* Unfortunately if you expect plans to be run multiple times you need to provide a function that returns a plan not just a plan. This is because after the first run the generator will be exhausted. I couldn't quickly think of anyway around this but open to suggestions right now this looks likes:

```python
EngineWidget(plan=lambda: count(...))
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #46 

## Screenshots
![engine](https://user-images.githubusercontent.com/25753048/37112686-002bb232-21f8-11e8-8b8a-73a40c499c3d.gif)


