### PR TITLE
DEV: Modify pytest kwargs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ application = None
 def pytest_addoption(parser):
     parser.addoption("--dark", action="store_true", default=False,
                      help="Use the dark stylesheet to display widgets")
-    parser.addoption("--show", action="store_true", default=False,
+    parser.addoption("--show-ui", action="store_true", default=False,
                      help="Show the widgets produced by each test")
 
 
@@ -33,7 +33,7 @@ def pytest_addoption(parser):
 @pytest.fixture(scope='session', autouse=True)
 def _show_widgets(pytestconfig):
     global show_widgets
-    show_widgets = pytestconfig.getoption('--show')
+    show_widgets = pytestconfig.getoption('--show-ui')
     if show_widgets:
         logger.info("Running tests while showing created widgets ...")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,31 +23,10 @@ application = None
 
 
 def pytest_addoption(parser):
-    parser.addoption("--log", action="store", default="INFO",
-                     help="Set the level of the log")
-    parser.addoption("--logfile", action="store", default=None,
-                     help="Write the log output to specified file path")
     parser.addoption("--dark", action="store_true", default=False,
                      help="Use the dark stylesheet to display widgets")
     parser.addoption("--show", action="store_true", default=False,
                      help="Show the widgets produced by each test")
-
-
-# Create a fixture to automatically instantiate logging setup
-@pytest.fixture(scope='session', autouse=True)
-def _set_level(pytestconfig):
-    # Read user input logging level
-    log_level = getattr(logging, pytestconfig.getoption('--log'), None)
-
-    # Report invalid logging level
-    if not isinstance(log_level, int):
-        raise ValueError("Invalid log level : {}".format(log_level))
-
-    # Create basic configuration
-    logging.basicConfig(level=log_level,
-                        filename=pytestconfig.getoption('--logfile'),
-                        format='%(asctime)s - %(levelname)s ' +
-                               '- %(name)s - %(message)s')
 
 
 # Create a fixture to configure whether widgets are shown or not


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Updated my version of `pytest` and ran into this issue https://github.com/pytest-dev/pytest/issues/3413.

The TL;DR is a combination of the argument parsing in `pytest` and the default `argparse` library does not like when one command line argument is just a shortened version of another.  In `pytest=3.5` it appears they added arguments that start with `show` so when ever I tried to use my argument I received

```bash
$ py.test --show
usage: py.test [options] [file_or_dir] [file_or_dir] [...]
py.test: error: ambiguous option: --show could match --showlocals, --show-capture
```

I have renamed `show` to `show-ui` and now there are no conflicts! Also, after #49 there is no need to have command line arguments to configure the logging setup. These have been deprecated.
