### PR TITLE
API: Remove hint plot replace with PyDMDrawingImage

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -101,13 +101,14 @@ def test_display_with_images(test_images):
     display = DeviceDisplay(device)
     # Add our main image
     display.add_image(python)
+    assert display.image_widget.filename == python
     # Add our component image
     display.add_image(lenna, subdevice=device.x)
-    assert not display.image_widget.isHidden()
     # Show our subdevice and image
     display.show_subdevice(device.x.name)
-    assert display.image_widget.currentWidget().filename == lenna
-    # Hide all subdevices and show main image
-    display.hide_subdevices()
-    assert display.image_widget.currentWidget().filename == python
+    sub_display = display.ui.component_widget.currentWidget()
+    assert sub_display.image_widget.filename == lenna
+    # Bad input
+    with pytest.raises(ValueError):
+        display.add_image(lenna, subdevice=device)
     return display

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -76,8 +76,6 @@ def test_display():
                    for disp in display.ui.component_widget.children()]
     assert all([getattr(device, dev) in sub_devices
                 for dev in device._sub_devices])
-    # Check that the hints are included in the plot
-    assert len(display.ui.hint_plot.curves) == 1
     return display
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -96,10 +96,12 @@ def test_display_with_funcs():
 @using_fake_epics_pv
 @show_widget
 def test_display_with_images(test_images):
-    device = MockDevice("Tst:Dev", name="MockDevice")
     (lenna, python) = test_images
-    display = DeviceDisplay(device)
-    # Add our main image
+    device = MockDevice("Tst:Dev", name="MockDevice")
+    # Create a display with our image
+    display = DeviceDisplay(device, image=lenna)
+    assert display.image_widget.filename == lenna
+    # Add our python image
     display.add_image(python)
     assert display.image_widget.filename == python
     # Add our component image

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -11,8 +11,7 @@ from pydm.PyQt.QtGui import QWidget
 ###########
 # Package #
 ###########
-from typhon.display import RotatingImage, ComponentButton
-from typhon.widgets import TogglePanel
+from typhon.widgets import RotatingImage, TogglePanel, ComponentButton
 from .conftest import show_widget
 
 

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -68,6 +68,7 @@ class TyphonDisplay(QWidget):
         self.misc_panel = SignalPanel("Miscellaneous", parent=self)
         # Add all the panels
         self.ui.main_layout.insertWidget(2, self.read_panel)
+        self.ui.main_layout.insertWidget(3, self.method_panel)
         # Create tabs
         self.ui.signal_tab.clear()
         self.add_tab('Configuration', self.config_panel)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -210,10 +210,6 @@ class TyphonDisplay(QWidget):
             self.ui.component_widget.show()
         # Show the correct subdevice widget
         self.ui.component_widget.setCurrentIndex(self.subdisplays[name])
-        # Show image if we have one for this subdevice
-        if (not self.image_widget.isHidden()
-           and name in self.image_widget.images):
-            self.image_widget.show_image(name)
 
     @pyqtSlot()
     def hide_subdevices(self):
@@ -224,9 +220,6 @@ class TyphonDisplay(QWidget):
         # Toggle the button off, each button can use its own pyqtSlot
         for button in self.device_button_group.buttons():
             button.toggled.emit(False)
-        if (not self.image_widget.isHidden()
-           and None in self.image_widget.images):
-            self.image_widget.show_image(None)
 
 
 class DeviceDisplay(TyphonDisplay):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -33,12 +33,10 @@ class TyphonDisplay(QWidget):
     one is not required to be given. There are four main panels available;
     :attr:`.read_panel`, :attr:`.config_panel`, :attr:`.method_panel`. These
     each provide a quick way to organize signals and methods by their
-    importance to an operator. In addition, crucial signals can be added to a
-    PyDMTimePlot under the attribute :attr:`.hint_plot`.  Because each panel
-    can be hidden interactively, the screen works as both an expert and novice
-    entry point for users. By default, widgets are hidden until contents are
-    added. For instance, if you do not add any methods to the main panel it
-    will not be visible.
+    importance to an operator. Because each panel can be hidden interactively,
+    the screen works as both an expert and novice entry point for users. By
+    default, widgets are hidden until contents are added. For instance, if you
+    do not add any methods to the main panel it will not be visible.
 
     This device is the bare bones implementation in the event that someone
     might want to collect a random group of signals and devices together to
@@ -52,9 +50,6 @@ class TyphonDisplay(QWidget):
 
     parent : QWidget, optional
     """
-    default_curve_opts = {'lineStyle': Qt.SolidLine, 'symbol': 'o',
-                          'lineWidth': 2, 'symbolSize': 4}
-
     def __init__(self, name, parent=None):
         # Instantiate Widget
         super().__init__(parent=parent)
@@ -81,7 +76,6 @@ class TyphonDisplay(QWidget):
         self.ui.buttons.hide()
         self.ui.component_widget.hide()
         self.method_panel.hide()
-        self.ui.hint_plot.hide()
 
     @property
     def methods(self):
@@ -155,29 +149,6 @@ class TyphonDisplay(QWidget):
                                           methods=methods,
                                           parent=self),
                             button=button)
-
-    def add_pv_to_plot(self, pv, **kwargs):
-        """
-        Add a PV to the PyDMTimePlot
-
-        The default style of the curve is determined by
-        :attr:`.default_curve_opts`. Though these can be overridden
-
-        Parameters
-        ----------
-        pvname : str
-            Name of PV
-
-        kwargs:
-            All keywords are passed directly to ``PyDMTimePlot.addYChannel``
-        """
-        # Show our plot if it was previously hidden
-        if self.ui.hint_plot.isHidden():
-            self.ui.hint_plot.show()
-        # Combine user supplied options with defaults
-        plot_opts = copy.copy(self.default_curve_opts)
-        plot_opts.update(kwargs)
-        self.ui.hint_plot.addYChannel(y_channel=channel_name(pv), **plot_opts)
 
     def add_tab(self, name, widget):
         qw = QWidget()
@@ -294,17 +265,3 @@ class DeviceDisplay(TyphonDisplay):
         methods = methods or list()
         for method in methods:
                 self.method_panel.add_method(method)
-
-        # Add our hints
-        for field in getattr(self.device, 'hints', {}).get('fields', list()):
-            try:
-                # Get a description of the signal. Add the the PV name
-                # to the hint_panel if it is a number and not a string
-                sig_desc = self.device_description[field]
-                if sig_desc['dtype'] == 'number':
-                    self.add_pv_to_plot(clean_source(sig_desc['source']))
-                else:
-                    logger.debug("Not adding %s because it is not a number",
-                                 field)
-            except KeyError as exc:
-                logger.error("Unable to find PV name of %s", field)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -19,7 +19,7 @@ from pydm.PyQt.QtGui import QWidget, QPushButton, QButtonGroup, QVBoxLayout
 from .func import FunctionPanel
 from .signal import SignalPanel
 from .utils import ui_dir, clean_attr, clean_source, clean_name, channel_name
-from .widgets import RotatingImage, ComponentButton
+from .widgets import ComponentButton
 
 logger = logging.getLogger(__name__)
 
@@ -71,10 +71,8 @@ class TyphonDisplay(QWidget):
         self.read_panel = SignalPanel("Read", parent=self)
         self.config_panel = SignalPanel("Configuration", parent=self)
         self.misc_panel = SignalPanel("Miscellaneous", parent=self)
-        self.image_widget = RotatingImage()
         # Add all the panels
         self.ui.main_layout.insertWidget(2, self.read_panel)
-        self.ui.widget_layout.insertWidget(0, self.image_widget)
         # Create tabs
         self.ui.signal_tab.clear()
         self.add_tab('Configuration', self.config_panel)
@@ -84,7 +82,6 @@ class TyphonDisplay(QWidget):
         self.ui.component_widget.hide()
         self.method_panel.hide()
         self.ui.hint_plot.hide()
-        self.image_widget.hide()
 
     @property
     def methods(self):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -49,9 +49,12 @@ class TyphonDisplay(QWidget):
     name : str
         Title displayed on the widget
 
+    image :str, optional
+        Path to an image file to include in the display.
+
     parent : QWidget, optional
     """
-    def __init__(self, name, parent=None):
+    def __init__(self, name, image=None, parent=None):
         # Instantiate Widget
         super().__init__(parent=parent)
         self.subdisplays = dict()
@@ -78,6 +81,11 @@ class TyphonDisplay(QWidget):
         self.ui.buttons.hide()
         self.ui.component_widget.hide()
         self.method_panel.hide()
+        # Create PyDMDrawingImage
+        if image:
+            self.add_image(image)
+        else:
+            self.image_widget = None
 
     @property
     def methods(self):
@@ -135,6 +143,9 @@ class TyphonDisplay(QWidget):
         device : ophyd.Device
 
         methods : list of callables, optional
+
+        image: str, optional
+            Path to image to display for device
         """
         logger.debug("Creating button for %s", device.name)
         # Create ComponentButton adding the hints automatically
@@ -149,6 +160,7 @@ class TyphonDisplay(QWidget):
         self.add_subdisplay(device.name,
                             DeviceDisplay(device,
                                           methods=methods,
+                                          image=image,
                                           parent=self),
                             button=button)
 
@@ -256,9 +268,12 @@ class DeviceDisplay(TyphonDisplay):
     methods : list of callables, optional
         List of callables to pass to :meth:`.FunctionPanel.add_method`
 
+    image : str, optional
+        Path to image to add to display
+
     parent : QWidget, optional
     """
-    def __init__(self, device, methods=None, parent=None):
+    def __init__(self, device, methods=None, image=None, parent=None):
         super().__init__(clean_name(device, strip_parent=False),
                          parent=parent)
         # Examine and store device for later reference

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -1,7 +1,6 @@
 ############
 # Standard #
 ############
-import copy
 import os.path
 import logging
 from functools import partial
@@ -19,7 +18,7 @@ from pydm.widgets.drawing import PyDMDrawingImage
 ###########
 from .func import FunctionPanel
 from .signal import SignalPanel
-from .utils import ui_dir, clean_attr, clean_source, clean_name, channel_name
+from .utils import ui_dir, clean_attr, clean_source, clean_name
 from .widgets import ComponentButton
 
 logger = logging.getLogger(__name__)
@@ -223,7 +222,6 @@ class TyphonDisplay(QWidget):
             self.image_widget.setMaximumSize(350, 350)
             self.ui.main_layout.insertWidget(2, self.image_widget,
                                              0, Qt.AlignCenter)
-
 
     @pyqtSlot()
     def show_subdevice(self, name):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -81,10 +81,9 @@ class TyphonDisplay(QWidget):
         self.ui.component_widget.hide()
         self.method_panel.hide()
         # Create PyDMDrawingImage
+        self.image_widget = None
         if image:
             self.add_image(image)
-        else:
-            self.image_widget = None
 
     @property
     def methods(self):
@@ -273,7 +272,7 @@ class DeviceDisplay(TyphonDisplay):
     """
     def __init__(self, device, methods=None, image=None, parent=None):
         super().__init__(clean_name(device, strip_parent=False),
-                         parent=parent)
+                         image=image, parent=parent)
         # Examine and store device for later reference
         self.device = device
         self.device_description = self.device.describe()

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -151,13 +151,28 @@ class TyphonDisplay(QWidget):
                             button=button)
 
     def add_tab(self, name, widget):
+        """
+        Add a widget to the main signal tab
+
+        Use this rather than directly setting ``signal_tab.addTab`` to ensure
+        that the tab has the proper stretch to avoid distorting the size of the
+        widget you are adding.
+
+        Parameters
+        ----------
+        name : str
+            Name that will be displayed on tab
+
+        widget : QWidget
+            Widget to be contained within the new tab
+        """
         qw = QWidget()
         qw.setLayout(QVBoxLayout())
         qw.layout().addWidget(widget)
         qw.layout().addStretch(1)
         self.ui.signal_tab.addTab(qw, name)
 
-    def add_image(self, path, subdevice=None):
+    def add_image(self, path):
         """
         Add an image to the display
 

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -197,7 +197,7 @@ class TyphonDisplay(QWidget):
             Absolute or relative path to image
 
         subdevice: ophyd.Device
-            Name of ophyd object that has been previously added with
+            Ophyd object that has been previously added with
             :meth:`.add_subdevice`
         """
         # Find the nested widget for this specific device

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -43,17 +43,23 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="main_layout" stretch="0,0">
+     <property name="maximumSize">
+      <size>
+       <width>450</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0">
       <property name="spacing">
        <number>5</number>
       </property>
       <property name="sizeConstraint">
-       <enum>QLayout::SetFixedSize</enum>
+       <enum>QLayout::SetMaximumSize</enum>
       </property>
       <item>
        <widget class="QFrame" name="title_frame">
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
          <enum>QFrame::Plain</enum>
@@ -82,6 +88,7 @@
           <widget class="QLabel" name="name_label">
            <property name="font">
             <font>
+             <family>Sans Serif</family>
              <pointsize>20</pointsize>
              <weight>75</weight>
              <bold>true</bold>
@@ -106,6 +113,25 @@
           </spacer>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="underline">
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::HLine</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>10</number>
+        </property>
        </widget>
       </item>
       <item>

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>520</width>
-    <height>599</height>
+    <height>862</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,7 +43,7 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0">
+     <layout class="QVBoxLayout" name="main_layout" stretch="0,0">
       <property name="spacing">
        <number>5</number>
       </property>
@@ -106,56 +106,6 @@
           </spacer>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="PyDMTimePlot" name="hint_plot">
-        <property name="minimumSize">
-         <size>
-          <width>350</width>
-          <height>350</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="whatsThis">
-         <string/>
-        </property>
-        <property name="showXGrid" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="showYGrid" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="axisColor" stdset="0">
-         <color>
-          <red>212</red>
-          <green>212</green>
-          <blue>212</blue>
-         </color>
-        </property>
-        <property name="showLegend" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="mouseEnabledX" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="curves" stdset="0">
-         <stringlist/>
-        </property>
-        <property name="bufferSize" stdset="0">
-         <number>60</number>
-        </property>
-        <property name="updatesAsynchronously" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="timeSpan" stdset="0">
-         <double>30.000000000000000</double>
-        </property>
-        <property name="updateInterval" stdset="0">
-         <double>0.500000000000000</double>
-        </property>
        </widget>
       </item>
       <item>
@@ -275,13 +225,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>PyDMTimePlot</class>
-   <extends>QGraphicsView</extends>
-   <header>pydm.widgets.timeplot</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In the new Typhon world order the `hint_plot` will be an expandable tool that will show up in the side bar of the application. This PR removes the `hint_plot` and all related functions and replaces it with  an image of the device. This is completely optional but it gives the user a better idea about what they are actually looking at. 

This is the last PR for now that will deal with the look of the main widget instead we will focus on the panel that allows operators to view other tools. This will restore the `hint_plot` functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #55 

## Screenshots (if appropriate):
![typhon_with_image](https://user-images.githubusercontent.com/25753048/40567705-5cf7437a-602b-11e8-9652-84364e2fa33b.png)
