### PR TITLE
ENH: Typhon Stylesheet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,12 @@ script:
   - coverage run run_tests.py --timeout 15 
   - coverage report -m
   - flake8 typhon
+  # Test again but with installed version
+  - mkdir notest
+  - mv typhon/*.* notest
+  - python run_tests.py
+  - mv notest/* typhon
+  - rmdir notest
   # Build docs
   - set -e
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ install:
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
   - conda config --append channels $PYDM_CHANNEL 
-  - conda config --append channels lightsource2-tag
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include typhon/_version.py
+include typhon/ui/base.ui
+include typhon/ui/style.qss

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include versioneer.py
 include typhon/_version.py
-include typhon/ui/base.ui
+include typhon/ui/*.ui
 include typhon/ui/style.qss

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -93,5 +93,3 @@ user displays.
 
 Making Modifications
 ====================
-
-

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -91,5 +91,11 @@ operator to view lower level details as they see fit. This allows for the
 representation of complex devices with nested structures in clean consistent
 user displays. 
 
+Using the StyleSheet
+====================
+While it is no means a requirement, Typhon ships with a custom stylesheet to
+improve the look of the widgets. By default this isn't activated, but can be
+configured with `:func:`.use_stylesheet`
+
 Making Modifications
 ====================

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ setup(name='typhon',
       cmdclass=versioneer.get_cmdclass(),
       author='SLAC National Accelerator Laboratory',
       packages=find_packages(),
+      include_package_data=True,
       description='Interface generation for ophyd devices',
       )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from pydm import PyDMApplication
 ###########
 # Package #
 ###########
+import typhon
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,8 @@ def qapp(pytestconfig):
         if pytestconfig.getoption('--dark'):
             import qdarkstyle
             application.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
+        else:
+            application.setStyleSheet(typhon.load_stylesheet())
     return application
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def qapp(pytestconfig):
             import qdarkstyle
             application.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
         else:
-            application.setStyleSheet(typhon.load_stylesheet())
+            typhon.use_stylesheet()
     return application
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -63,6 +63,7 @@ class MockDevice(Device):
 @show_widget
 def test_display():
     device = MockDevice("Tst:Dev", name="MockDevice")
+    device.wait_for_connection()
     display = DeviceDisplay(device)
     # We have all our signals
     shown_read_sigs = list(display.read_panel.pvs.keys())
@@ -83,6 +84,7 @@ def test_display():
 @show_widget
 def test_display_with_funcs():
     device = MockDevice("Tst:Dev", name="MockDevice")
+    device.wait_for_connection()
     display = DeviceDisplay(device, methods=[device.insert,
                                              device.remove])
     # The method panel is visible
@@ -98,6 +100,7 @@ def test_display_with_funcs():
 def test_display_with_images(test_images):
     (lenna, python) = test_images
     device = MockDevice("Tst:Dev", name="MockDevice")
+    device.wait_for_connection()
     # Create a display with our image
     display = DeviceDisplay(device, image=lenna)
     assert display.image_widget.filename == lenna

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,6 @@
+from typhon.utils import load_stylesheet
+
+
+def test_stylesheet():
+    sty = load_stylesheet()
+    assert 'QWidget' in sty

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
-from typhon.utils import load_stylesheet
+from typhon.utils import use_stylesheet
 
 
 def test_stylesheet():
-    sty = load_stylesheet()
-    assert 'QWidget' in sty
+    use_stylesheet()

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -2,7 +2,7 @@ __all__ = ['TyphonDisplay', 'DeviceDisplay', 'ComponentButton',
            'load_stylesheet']
 from .display import TyphonDisplay, DeviceDisplay
 from .widgets import ComponentButton
-from .utils import load_stylesheet
+from .utils import use_stylesheet
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['TyphonDisplay', 'DeviceDisplay', 'ComponentButton',
-           'load_stylesheet']
+           'use_stylesheet']
 from .display import TyphonDisplay, DeviceDisplay
 from .widgets import ComponentButton
 from .utils import use_stylesheet

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,6 +1,8 @@
-__all__ = ['TyphonDisplay', 'DeviceDisplay', 'ComponentButton']
+__all__ = ['TyphonDisplay', 'DeviceDisplay', 'ComponentButton',
+           'load_stylesheet']
 from .display import TyphonDisplay, DeviceDisplay
 from .widgets import ComponentButton
+from .utils import load_stylesheet
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/typhon/ui/style.qss
+++ b/typhon/ui/style.qss
@@ -1,0 +1,38 @@
+QWidget{
+   background-color: #ffffff;
+   color: black;
+   font: bold;
+}
+
+PyDMLineEdit {
+    color: #A9A9A9;
+}
+
+PyDMLineEdit:focus {
+    border-color: blue;
+    color: black;
+}
+
+PyDMLabel {
+    color: white;
+    background-color: #0b3ae8;
+    border-radius: 5px;
+}
+
+QComboBox {
+    border-radius 10px;
+    color: #A9A9A9;
+}
+
+QComboBox:on {
+    color: black;
+}
+
+QComboBox QAbstractItemView {
+    border: 2px solid #0b3ae8;
+    border-radius 10px;
+}
+
+QComboBox:hover {
+    border: 2px solid #0b3ae8;
+}

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -9,6 +9,7 @@ import os.path
 ############
 # External #
 ############
+from pydm.PyQt.QtGui import QApplication
 
 #############
 #  Package  #
@@ -57,9 +58,9 @@ def clean_name(device, strip_parent=True):
     return clean_attr(name)
 
 
-def load_stylesheet():
+def use_stylesheet():
     """
-    Load the Typhon Stylesheet
+    Use the Typhon stylesheet
     """
     # Load the path to the file
     style_path = os.path.join(ui_dir, 'style.qss')
@@ -68,4 +69,5 @@ def load_stylesheet():
                                "".format(style_path))
     # Load the stylesheet from the file
     with open(style_path, 'r') as handle:
-        return handle.read()
+        app = QApplication.instance()
+        app.setStyleSheet(handle.read())

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -55,3 +55,17 @@ def clean_name(device, strip_parent=True):
         name = name.lstrip(device.parent.name + '_')
     # Return the cleaned alias
     return clean_attr(name)
+
+
+def load_stylesheet():
+    """
+    Load the Typhon Stylesheet
+    """
+    # Load the path to the file
+    style_path = os.path.join(ui_dir, 'style.qss')
+    if not os.path.exists(style_path):
+        raise EnvironmentError("Unable to find Typhon stylesheet in {}"
+                               "".format(style_path))
+    # Load the stylesheet from the file
+    with open(style_path, 'r') as handle:
+        return handle.read()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Formalized loading of the custom Typhon stylesheet I've been assembling over the last few months. This by no means the last iteration, but I wanted to make sure we are placing this in a consistent place within the library and distributing it regardless of packaging choice.

* Use `conda-forge` version of `ophyd`
* Added a `style.qss` file in `typhon/ui`
* Added a helper function to load the stylesheet
* Update `MANFIEST.in` to store `ui` and `qss` files
* Test that we have all functionality when package is not installed from source. Tests are now done twice; once from source, once from install to check packaging instructions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #57 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We now run tests with the stylesheet by default. Also explicitly check the `load_stylesheet` function.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added stylesheet instructions in Basic Usage Section

