### PR TITLE
ENH: SignalPlugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,12 @@ script:
   - coverage run run_tests.py --timeout 15 
   - coverage report -m
   - flake8 typhon
+  # Test again but with installed version
+  - mkdir notest
+  - mv typhon/*.* notest
+  - python run_tests.py
+  - mv notest/* typhon
+  - rmdir notest
   # Build docs
   - set -e
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ install:
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
   - conda config --append channels $PYDM_CHANNEL 
-  - conda config --append channels lightsource2-tag
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include typhon/_version.py
+include typhon/ui/base.ui
+include typhon/ui/style.qss

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include versioneer.py
 include typhon/_version.py
-include typhon/ui/base.ui
+include typhon/ui/*.ui
 include typhon/ui/style.qss

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -93,5 +93,3 @@ user displays.
 
 Making Modifications
 ====================
-
-

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ setup(name='typhon',
       cmdclass=versioneer.get_cmdclass(),
       author='SLAC National Accelerator Laboratory',
       packages=find_packages(),
+      include_package_data=True,
       description='Interface generation for ophyd devices',
       )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from pydm import PyDMApplication
 ###########
 # Package #
 ###########
+import typhon
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,8 @@ def qapp(pytestconfig):
         if pytestconfig.getoption('--dark'):
             import qdarkstyle
             application.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
+        else:
+            application.setStyleSheet(typhon.load_stylesheet())
     return application
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,51 @@
+from ophyd import Signal
+from pydm.widgets.base import PyDMWritableWidget
+from pydm.PyQt.QtGui import QWidget
+
+from typhon.plugins.core import (SignalPlugin, SignalConnection,
+                                 register_signal)
+
+class WritableWidget(QWidget, PyDMWritableWidget):
+    """Simple Testing Widget"""
+    pass
+
+
+def test_signal_connection(qapp):
+    # Create a signal and attach our listener
+    sig = Signal(name='my_signal', value=1)
+    register_signal(sig)
+    widget = WritableWidget()
+    listener = widget.channels()[0]
+    sig_conn = SignalConnection("sig://my_signal",
+                                "my_signal")
+    sig_conn.add_listener(listener)
+    # Check that our widget receives the initial value
+    qapp.processEvents()
+    assert widget._write_access
+    assert widget._connected
+    assert widget.value == 1
+    # Check that we can push values back to the signal which in turn causes the
+    # internal value at the widget to update
+    widget.send_value_signal.emit(2)
+    qapp.processEvents()
+    qapp.processEvents()  # Must be called twice. Multiple rounds of signals
+    assert sig.get() == 2
+    assert widget.value == 2
+    sig_conn.remove_listener(listener)
+    # Check that our signal is disconnected completely and maintains the same
+    # value as the signal updates in the background
+    sig.put(3)
+    qapp.processEvents()
+    assert widget.value == 2
+    widget.send_value_signal.emit(1)
+    qapp.processEvents()
+    assert sig.get() == 3
+
+def test_invalid_signal():
+    widget = WritableWidget()
+    listener = widget.channels()[0]
+    # Invalid Signal
+    sig_conn = SignalConnection("sig://not_my_signal",
+                                "not_my_signal")
+    assert not widget._connected
+    assert not widget._write_access

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,6 @@
+from typhon.utils import load_stylesheet
+
+
+def test_stylesheet():
+    sty = load_stylesheet()
+    assert 'QWidget' in sty

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,6 +1,8 @@
-__all__ = ['TyphonDisplay', 'DeviceDisplay', 'ComponentButton']
+__all__ = ['TyphonDisplay', 'DeviceDisplay', 'ComponentButton',
+           'load_stylesheet']
 from .display import TyphonDisplay, DeviceDisplay
 from .widgets import ComponentButton
+from .utils import load_stylesheet
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ['SignalPlugin', 'SignalConnection', 'register_signal']
+from .core import SignalPlugin, SignalConnection, register_signal

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,2 +1,8 @@
 __all__ = ['SignalPlugin', 'SignalConnection', 'register_signal']
+
+from pydm.data_plugins import add_plugin
+
 from .core import SignalPlugin, SignalConnection, register_signal
+
+# Register SignalPlugin with PyDMApplication
+add_plugin(SignalPlugin)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -1,0 +1,149 @@
+"""
+Module Docstring
+"""
+############
+# Standard #
+############
+import logging
+
+###############
+# Third Party #
+###############
+import numpy as np
+from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
+from pydm.PyQt.QtCore import pyqtSlot, Qt
+
+##########
+# Module #
+##########
+
+logger = logging.getLogger(__name__)
+
+signal_registry = dict()
+
+
+def register_signal(signal):
+    """Add a new Signal to the registry"""
+    # Warn the user if they are adding twice
+    if signal.name in signal_registry:
+        logger.error("A signal named %s is already registered!", signal.name)
+        return
+    signal_registry[signal.name] = signal
+
+
+class SignalConnection(PyDMConnection):
+    """
+    Connection to monitor an Ophyd Signal
+
+    This is meant as a generalized connection to any type of Ophyd Signal. It
+    handles reporting updates to listeners as well as pushing new values that
+    users request in the PyDM interface back to the underlying signal
+
+    Attributes
+    ----------
+    signal : ophyd.Signal
+        Stored signal object
+
+    Example
+    -------
+    .. code:: python
+        conn = ClassConnection('sig://ophyd.Signal|name=Test',)
+                               'ophyd.Signal|name=Test')
+    """
+    supported_types = [int, float, str, np.ndarray]
+
+    def __init__(self, channel, address, protocol=None, parent=None):
+        # Create base connection
+        super().__init__(channel, address, protocol=protocol, parent=parent)
+        self.signal_type = None
+        # Get Signal from registry
+        try:
+            self.signal = signal_registry[address]
+        except KeyError as exc:
+            logger.exception("Unable to find signal %s in signal registry."
+                             "Use typhon.plugins.register_signal()",
+                             address)
+            # Report as disconnected
+            self.signal = None
+        else:
+            # Subscribe to updates from Ophyd
+            self.signal.subscribe(self.send_new_value,
+                                  event_type=self.signal.SUB_VALUE)
+
+    @pyqtSlot(int)
+    @pyqtSlot(float)
+    @pyqtSlot(str)
+    @pyqtSlot(np.ndarray)
+    def put_value(self, new_val):
+        """
+        Pass a value from the UI to Signal
+        We are not guaranteed that this signal is writeable so catch exceptions
+        if they are created
+        """
+        try:
+            self.signal.put(new_val)
+        except Exception as exc:
+            logger.exception("Unable to put %r to %s", new_val, self.address)
+
+    def send_new_value(self, value=None, **kwargs):
+        """
+        Update the UI with a new value from the Signal
+        """
+        # If this is the first time we are receiving a new value note the type
+        # We make the assumption that signals do not change types during a
+        # connection
+        if not self.signal_type:
+            self.signal_type = type(value)
+        self.new_value_signal[self.signal_type].emit(value)
+
+    def add_listener(self, channel):
+        """
+        Add a listener channel to this connection
+        This attaches values input by the user to the `send_new_value` function
+        in order to update the Signal object in addition to the default setup
+        performed in PyDMConnection
+        """
+        # Perform the default connection setup
+        super().add_listener(channel)
+        # Send the most recent value to the channel
+        if self.signal:
+            # Report as connected
+            self.write_access_signal.emit(True)
+            self.connection_state_signal.emit(True)
+            self.send_new_value(value=self.signal.get())
+            # If the channel is used for writing to PVs, hook it up to the
+            # 'put' methods.
+            if channel.value_signal is not None:
+                for _typ in self.supported_types:
+                    try:
+                        val_sig = channel.value_signal[_typ]
+                        val_sig.connect(self.put_value, Qt.QueuedConnection)
+                    except KeyError:
+                        logger.debug("%s has no value_signal for type %s",
+                                     channel.address, _typ)
+        else:
+            self.write_access_signal.emit(False)
+            self.connection_state_signal.emit(False)
+
+    def remove_listener(self, channel):
+        """
+        Remove a listener channel from this connection
+
+        This removes the `send_new_value` connections from the channel in
+        addition to the default disconnection performed in PyDMConnection
+        """
+        # Disconnect put_value from outgoing channel
+        if channel.value_signal is not None:
+            for _typ in self.supported_types:
+                try:
+                    channel.value_signal[_typ].disconnect(self.put_value)
+                except KeyError:
+                    logger.debug("Unable to disconnect value_signal from %s "
+                                 "for type %s", channel.address, _typ)
+        # Disconnect any other signals
+        super().remove_listener(channel)
+
+
+class SignalPlugin(PyDMPlugin):
+    protocol = 'sig'
+    connection_class = SignalConnection

--- a/typhon/ui/style.qss
+++ b/typhon/ui/style.qss
@@ -1,0 +1,38 @@
+QWidget{
+   background-color: #ffffff;
+   color: black;
+   font: bold;
+}
+
+PyDMLineEdit {
+    color: #A9A9A9;
+}
+
+PyDMLineEdit:focus {
+    border-color: blue;
+    color: black;
+}
+
+PyDMLabel {
+    color: white;
+    background-color: #0b3ae8;
+    border-radius: 5px;
+}
+
+QComboBox {
+    border-radius 10px;
+    color: #A9A9A9;
+}
+
+QComboBox:on {
+    color: black;
+}
+
+QComboBox QAbstractItemView {
+    border: 2px solid #0b3ae8;
+    border-radius 10px;
+}
+
+QComboBox:hover {
+    border: 2px solid #0b3ae8;
+}

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -55,3 +55,17 @@ def clean_name(device, strip_parent=True):
         name = name.lstrip(device.parent.name + '_')
     # Return the cleaned alias
     return clean_attr(name)
+
+
+def load_stylesheet():
+    """
+    Load the Typhon Stylesheet
+    """
+    # Load the path to the file
+    style_path = os.path.join(ui_dir, 'style.qss')
+    if not os.path.exists(style_path):
+        raise EnvironmentError("Unable to find Typhon stylesheet in {}"
+                               "".format(style_path))
+    # Load the stylesheet from the file
+    with open(style_path, 'r') as handle:
+        return handle.read()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This should look very familiar. The last attempt did not take into account that we never want to recreate `ophyd` signals in the new `PyDMConnection` object. This new approach abandons the idea that we would every want to support the `SignalPlugin` from the `QtDesigner`, instead you register all the signals that you will need to create links for; then create the widgets that reference those signals.

```python
syn = ophyd.SynSignal(..., name='test_signal')
register_signal(syn)
widget  = PyDMWidget('sig://test_signal')
```

This is a little cumbersome but in reality most users will not be calling these by themselves. When they create a `DeviceDisplay` we can pass through their device and register signals for them.  

**Note** This won't pass all the tests until a new tag of PyDM is created

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #47 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a `PyDMWritableWidget`

## Documentation
Still lacking. Will fill this in if the approach is considered valid.