### PR TITLE
ENH: SignalPlugin

### DIFF
--- a/docs/source/connections.rst
+++ b/docs/source/connections.rst
@@ -1,0 +1,33 @@
+=======================
+Application Connections
+=======================
+
+Ophyd Signals
+=============
+Typhon takes advantage of the flexible data plugin system contained within
+``PyDM`` and the abstraction of the "control layer" within ``Ophyd``. In the
+:class:`.SignalPanel`, objects signals are queried for their type. If these are
+determined to be coming from ``EPICS`` the data plugin configured within
+``PyDM`` is used directly, any other kind of signal goes through the generic
+:class:`.SignalPlugin`. This uses the subscription system contained within
+``Ophyd`` to keep widgets values updated. One caveat is that ``PyDM`` requires
+that channels are specified by a string identifier. In the case of
+``ophyd.Signal`` objects we want to ensure that these are passed by reference
+to avoid duplicating objects. This means the workflow for adding these has one
+more additonal step where the ``Signal`` is registered with the ``PyDM``
+plugin.
+
+.. code:: python
+
+   from typhon.plugins import register_signal
+
+   # Create an Ophyd Signal
+   my_signal = ophyd.Signal(name='this_signal')
+   # Register this with the Plugin
+   register_signal(my_signal)
+   # This signal is now available for use with PyDM widgets
+   PyDMWidget(channel='sig://this_signal')
+
+
+Note that this is all done for you if you use the :class:`.SignalPanel`, but
+maybe useful if you would like to use the :class:`.SignalPlugin` directly.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ Related Projects
    :hidden:
 
    basic_usage.rst
+   connections.rst
    python_methods.rst
 
 .. toctree::
@@ -47,3 +48,4 @@ Related Projects
 
    display.rst
    widgets.rst
+   plugins.rst

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,0 +1,12 @@
+==============
+Typhon Plugins
+==============
+
+SignalPlugin
+============
+.. autofunction:: typhon.plugins.register_signal
+
+.. autoclass:: typhon.plugins.SignalConnection
+   :members:
+
+.. autoclass:: typhon.plugins.SignalPlugin

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -16,8 +16,7 @@ def test_signal_connection(qapp):
     register_signal(sig)
     widget = WritableWidget()
     listener = widget.channels()[0]
-    sig_conn = SignalConnection("sig://my_signal",
-                                "my_signal")
+    sig_conn = SignalConnection(listener, 'my_signal')
     sig_conn.add_listener(listener)
     # Check that our widget receives the initial value
     qapp.processEvents()
@@ -26,11 +25,14 @@ def test_signal_connection(qapp):
     assert widget.value == 1
     # Check that we can push values back to the signal which in turn causes the
     # internal value at the widget to update
-    widget.send_value_signal.emit(2)
+    widget.send_value_signal[int].emit(2)
     qapp.processEvents()
     qapp.processEvents()  # Must be called twice. Multiple rounds of signals
     assert sig.get() == 2
     assert widget.value == 2
+    # Try changing types
+    qapp.processEvents()
+    qapp.processEvents()  # Must be called twice. Multiple rounds of signals
     sig_conn.remove_listener(listener)
     # Check that our signal is disconnected completely and maintains the same
     # value as the signal updates in the background
@@ -45,7 +47,6 @@ def test_invalid_signal():
     widget = WritableWidget()
     listener = widget.channels()[0]
     # Invalid Signal
-    sig_conn = SignalConnection("sig://not_my_signal",
-                                "not_my_signal")
+    sig_conn = SignalConnection(listener, 'my_signal')
     assert not widget._connected
     assert not widget._write_access

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,51 @@
+from ophyd import Signal
+from pydm.widgets.base import PyDMWritableWidget
+from pydm.PyQt.QtGui import QWidget
+
+from typhon.plugins.core import (SignalPlugin, SignalConnection,
+                                 register_signal)
+
+class WritableWidget(QWidget, PyDMWritableWidget):
+    """Simple Testing Widget"""
+    pass
+
+
+def test_signal_connection(qapp):
+    # Create a signal and attach our listener
+    sig = Signal(name='my_signal', value=1)
+    register_signal(sig)
+    widget = WritableWidget()
+    listener = widget.channels()[0]
+    sig_conn = SignalConnection("sig://my_signal",
+                                "my_signal")
+    sig_conn.add_listener(listener)
+    # Check that our widget receives the initial value
+    qapp.processEvents()
+    assert widget._write_access
+    assert widget._connected
+    assert widget.value == 1
+    # Check that we can push values back to the signal which in turn causes the
+    # internal value at the widget to update
+    widget.send_value_signal.emit(2)
+    qapp.processEvents()
+    qapp.processEvents()  # Must be called twice. Multiple rounds of signals
+    assert sig.get() == 2
+    assert widget.value == 2
+    sig_conn.remove_listener(listener)
+    # Check that our signal is disconnected completely and maintains the same
+    # value as the signal updates in the background
+    sig.put(3)
+    qapp.processEvents()
+    assert widget.value == 2
+    widget.send_value_signal.emit(1)
+    qapp.processEvents()
+    assert sig.get() == 3
+
+def test_invalid_signal():
+    widget = WritableWidget()
+    listener = widget.channels()[0]
+    # Invalid Signal
+    sig_conn = SignalConnection("sig://not_my_signal",
+                                "not_my_signal")
+    assert not widget._connected
+    assert not widget._write_access

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ['SignalPlugin', 'SignalConnection', 'register_signal']
+from .core import SignalPlugin, SignalConnection, register_signal

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,2 +1,8 @@
 __all__ = ['SignalPlugin', 'SignalConnection', 'register_signal']
+
+from pydm.data_plugins import add_plugin
+
 from .core import SignalPlugin, SignalConnection, register_signal
+
+# Register SignalPlugin with PyDMApplication
+add_plugin(SignalPlugin)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -108,7 +108,12 @@ class SignalConnection(PyDMConnection):
             dtype = self.signal.describe()[self.signal.name]['dtype']
             # Only way this raises a KeyError is if ophyd is confused
             self.signal_type =  _type_map[dtype][0]
-        self.new_value_signal[self.signal_type].emit(value)
+        if type(value) == self.signal_type:
+            self.new_value_signal[self.signal_type].emit(value)
+        else:
+            logger.error("Value %r does not match %r, "
+                         "the reported data type of %s",
+                         value, self.signal_type, self.signal.name)
 
     def add_listener(self, channel):
         """

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -108,12 +108,12 @@ class SignalConnection(PyDMConnection):
             dtype = self.signal.describe()[self.signal.name]['dtype']
             # Only way this raises a KeyError is if ophyd is confused
             self.signal_type = _type_map[dtype][0]
-        if type(value) == self.signal_type:
+        try:
+            value = self.signal_type(value)
             self.new_value_signal[self.signal_type].emit(value)
-        else:
-            logger.error("Value %r does not match %r, "
-                         "the reported data type of %s",
-                         value, self.signal_type, self.signal.name)
+        except Exception:
+            logger.exception("Unable to update %r with value %r.",
+                             self.signal.name, value)
 
     def add_listener(self, channel):
         """

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -107,7 +107,7 @@ class SignalConnection(PyDMConnection):
         if not self.signal_type:
             dtype = self.signal.describe()[self.signal.name]['dtype']
             # Only way this raises a KeyError is if ophyd is confused
-            self.signal_type =  _type_map[dtype][0]
+            self.signal_type = _type_map[dtype][0]
         if type(value) == self.signal_type:
             self.new_value_signal[self.signal_type].emit(value)
         else:

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -10,6 +10,7 @@ import logging
 # Third Party #
 ###############
 import numpy as np
+from ophyd.utils.epics_pvs import _type_map
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from pydm.PyQt.QtCore import pyqtSlot, Qt
 
@@ -44,6 +45,10 @@ class SignalConnection(PyDMConnection):
     This is meant as a generalized connection to any type of Ophyd Signal. It
     handles reporting updates to listeners as well as pushing new values that
     users request in the PyDM interface back to the underlying signal
+
+    The signal `data_type` is used to inform PyDM on the Python type that the
+    signal will expect and emit. It is expected that this type is static
+    through the execution of the application
 
     Attributes
     ----------
@@ -96,7 +101,9 @@ class SignalConnection(PyDMConnection):
         # We make the assumption that signals do not change types during a
         # connection
         if not self.signal_type:
-            self.signal_type = type(value)
+            dtype = self.signal.describe()[self.signal.name]['dtype']
+            # Only way this raises a KeyError is if ophyd is confused
+            self.signal_type =  _type_map[dtype][0]
         self.new_value_signal[self.signal_type].emit(value)
 
     def add_listener(self, channel):

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -69,6 +69,8 @@ class SignalConnection(PyDMConnection):
             # Subscribe to updates from Ophyd
             self.signal.subscribe(self.send_new_value,
                                   event_type=self.signal.SUB_VALUE)
+        # Add listener
+        self.add_listener(channel)
 
     @pyqtSlot(int)
     @pyqtSlot(float)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -86,9 +86,13 @@ class SignalConnection(PyDMConnection):
         Pass a value from the UI to Signal
 
         We are not guaranteed that this signal is writeable so catch exceptions
-        if they are created
+        if they are created. We attempt to cast the received value into the
+        reported type of the signal unless it is of type ``np.ndarray``
         """
         try:
+            # Cast into the correct type
+            if self.signal_type is not np.ndarray:
+                new_val = self.signal_type(new_val)
             self.signal.put(new_val)
         except Exception as exc:
             logger.exception("Unable to put %r to %s", new_val, self.address)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -23,7 +23,13 @@ signal_registry = dict()
 
 
 def register_signal(signal):
-    """Add a new Signal to the registry"""
+    """
+    Add a new Signal to the registry
+
+    The Signal object is kept within ``signal_registry`` for reference by name
+    in the :class:`.SignalConnection`. Signals can be added multiple times and
+    overwritten but a warning will be emitted.
+    """
     # Warn the user if they are adding twice
     if signal.name in signal_registry:
         logger.error("A signal named %s is already registered!", signal.name)
@@ -43,12 +49,6 @@ class SignalConnection(PyDMConnection):
     ----------
     signal : ophyd.Signal
         Stored signal object
-
-    Example
-    -------
-    .. code:: python
-        conn = ClassConnection('sig://ophyd.Signal|name=Test',)
-                               'ophyd.Signal|name=Test')
     """
     supported_types = [int, float, str, np.ndarray]
 
@@ -77,6 +77,7 @@ class SignalConnection(PyDMConnection):
     def put_value(self, new_val):
         """
         Pass a value from the UI to Signal
+
         We are not guaranteed that this signal is writeable so catch exceptions
         if they are created
         """
@@ -99,6 +100,7 @@ class SignalConnection(PyDMConnection):
     def add_listener(self, channel):
         """
         Add a listener channel to this connection
+
         This attaches values input by the user to the `send_new_value` function
         in order to update the Signal object in addition to the default setup
         performed in PyDMConnection
@@ -145,5 +147,6 @@ class SignalConnection(PyDMConnection):
 
 
 class SignalPlugin(PyDMPlugin):
+    """Plugin registered with PyDM to handle SignalConnection"""
     protocol = 'sig'
     connection_class = SignalConnection

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -1,0 +1,149 @@
+"""
+Module Docstring
+"""
+############
+# Standard #
+############
+import logging
+
+###############
+# Third Party #
+###############
+import numpy as np
+from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
+from pydm.PyQt.QtCore import pyqtSlot, Qt
+
+##########
+# Module #
+##########
+
+logger = logging.getLogger(__name__)
+
+signal_registry = dict()
+
+
+def register_signal(signal):
+    """Add a new Signal to the registry"""
+    # Warn the user if they are adding twice
+    if signal.name in signal_registry:
+        logger.error("A signal named %s is already registered!", signal.name)
+        return
+    signal_registry[signal.name] = signal
+
+
+class SignalConnection(PyDMConnection):
+    """
+    Connection to monitor an Ophyd Signal
+
+    This is meant as a generalized connection to any type of Ophyd Signal. It
+    handles reporting updates to listeners as well as pushing new values that
+    users request in the PyDM interface back to the underlying signal
+
+    Attributes
+    ----------
+    signal : ophyd.Signal
+        Stored signal object
+
+    Example
+    -------
+    .. code:: python
+        conn = ClassConnection('sig://ophyd.Signal|name=Test',)
+                               'ophyd.Signal|name=Test')
+    """
+    supported_types = [int, float, str, np.ndarray]
+
+    def __init__(self, channel, address, protocol=None, parent=None):
+        # Create base connection
+        super().__init__(channel, address, protocol=protocol, parent=parent)
+        self.signal_type = None
+        # Get Signal from registry
+        try:
+            self.signal = signal_registry[address]
+        except KeyError as exc:
+            logger.exception("Unable to find signal %s in signal registry."
+                             "Use typhon.plugins.register_signal()",
+                             address)
+            # Report as disconnected
+            self.signal = None
+        else:
+            # Subscribe to updates from Ophyd
+            self.signal.subscribe(self.send_new_value,
+                                  event_type=self.signal.SUB_VALUE)
+
+    @pyqtSlot(int)
+    @pyqtSlot(float)
+    @pyqtSlot(str)
+    @pyqtSlot(np.ndarray)
+    def put_value(self, new_val):
+        """
+        Pass a value from the UI to Signal
+        We are not guaranteed that this signal is writeable so catch exceptions
+        if they are created
+        """
+        try:
+            self.signal.put(new_val)
+        except Exception as exc:
+            logger.exception("Unable to put %r to %s", new_val, self.address)
+
+    def send_new_value(self, value=None, **kwargs):
+        """
+        Update the UI with a new value from the Signal
+        """
+        # If this is the first time we are receiving a new value note the type
+        # We make the assumption that signals do not change types during a
+        # connection
+        if not self.signal_type:
+            self.signal_type = type(value)
+        self.new_value_signal[self.signal_type].emit(value)
+
+    def add_listener(self, channel):
+        """
+        Add a listener channel to this connection
+        This attaches values input by the user to the `send_new_value` function
+        in order to update the Signal object in addition to the default setup
+        performed in PyDMConnection
+        """
+        # Perform the default connection setup
+        super().add_listener(channel)
+        # Send the most recent value to the channel
+        if self.signal:
+            # Report as connected
+            self.write_access_signal.emit(True)
+            self.connection_state_signal.emit(True)
+            self.send_new_value(value=self.signal.get())
+            # If the channel is used for writing to PVs, hook it up to the
+            # 'put' methods.
+            if channel.value_signal is not None:
+                for _typ in self.supported_types:
+                    try:
+                        val_sig = channel.value_signal[_typ]
+                        val_sig.connect(self.put_value, Qt.QueuedConnection)
+                    except KeyError:
+                        logger.debug("%s has no value_signal for type %s",
+                                     channel.address, _typ)
+        else:
+            self.write_access_signal.emit(False)
+            self.connection_state_signal.emit(False)
+
+    def remove_listener(self, channel):
+        """
+        Remove a listener channel from this connection
+
+        This removes the `send_new_value` connections from the channel in
+        addition to the default disconnection performed in PyDMConnection
+        """
+        # Disconnect put_value from outgoing channel
+        if channel.value_signal is not None:
+            for _typ in self.supported_types:
+                try:
+                    channel.value_signal[_typ].disconnect(self.put_value)
+                except KeyError:
+                    logger.debug("Unable to disconnect value_signal from %s "
+                                 "for type %s", channel.address, _typ)
+        # Disconnect any other signals
+        super().remove_listener(channel)
+
+
+class SignalPlugin(PyDMPlugin):
+    protocol = 'sig'
+    connection_class = SignalConnection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This should look very familiar. The last attempt did not take into account that we never want to recreate `ophyd` signals in the new `PyDMConnection` object. This new approach abandons the idea that we would every want to support the `SignalPlugin` from the `QtDesigner`, instead you register all the signals that you will need to create links for; then create the widgets that reference those signals.

```python
syn = ophyd.SynSignal(..., name='test_signal')
register_signal(syn)
widget  = PyDMWidget('sig://test_signal')
```

This is a little cumbersome but in reality most users will not be calling these by themselves. When they create a `DeviceDisplay` we can pass through their device and register signals for them.  

**Note** This won't pass all the tests until a new tag of PyDM is created

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #28 
Closes #44 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a `PyDMWritableWidget`

## Documentation
Still lacking. Will fill this in if the approach is considered valid.