### PR TITLE
API: Sidebar

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -125,7 +125,7 @@ def test_subdisplay(qapp):
     # Set display by Device component
     display = DeviceDisplay(device)
     display.show_subdisplay(device.x)
-    assert not display.ui.subdisplay.isHidden()
+    assert not display.ui.subwindow.isHidden()
     assert display.ui.subdisplay.currentWidget().device == device.x
     # Set display by name
     display.show_subdisplay(clean_name(device.y))
@@ -140,6 +140,7 @@ def test_subdisplay(qapp):
     assert display.ui.subdisplay.currentWidget() == w
     # Hide all our subdisplays
     display.hide_subdisplays()
+    assert display.ui.subwindow.isHidden()
     assert display.ui.tool_list.selectedIndexes() == []
     assert display.ui.tool_list.selectedIndexes() == []
     return display

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -74,7 +74,7 @@ def test_display():
                 for sig in device.configuration_attrs])
     # We have all our subdevices
     sub_devices = [getattr(disp, 'device', None)
-                   for disp in display.ui.component_widget.children()]
+                   for disp in display.ui.subdisplay.children()]
     assert all([getattr(device, dev) in sub_devices
                 for dev in device._sub_devices])
     return display
@@ -110,8 +110,7 @@ def test_display_with_images(test_images):
     # Add our component image
     display.add_image(lenna, subdevice=device.x)
     # Show our subdevice and image
-    display.show_subdevice(device.x.name)
-    sub_display = display.ui.component_widget.currentWidget()
+    sub_display = display.get_subdisplay(device.x)
     assert sub_display.image_widget.filename == lenna
     # Bad input
     with pytest.raises(ValueError):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -127,7 +127,7 @@ class TyphonDisplay(QWidget):
         if list_widget.isHidden():
             list_widget.show()
 
-    def add_subdevice(self, device, methods=None, image=None):
+    def add_subdevice(self, device, **kwargs):
         """
         Add a subdevice to the `component_widget` stack
 
@@ -140,15 +140,6 @@ class TyphonDisplay(QWidget):
         image: str, optional
             Path to image to display for device
         """
-        logger.debug("Creating button for %s", device.name)
-        # Create ComponentButton adding the hints automatically
-        button = ComponentButton(clean_name(device), parent=self)
-        description = device.describe()
-        for field in getattr(device, 'hints', {}).get('fields', list()):
-            sig_source = description[field]['source']
-            button.add_pv(clean_source(sig_source), clean_attr(field))
-        # Create the actual subdisplay and add it to the component widget
-        # along with the button
         logger.debug("Creating subdisplay for %s", device.name)
         self.add_subdisplay(device.name,
                             DeviceDisplay(device,

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -10,7 +10,7 @@ from ophyd import Device
 ############
 from pydm.PyQt import uic
 from pydm.PyQt.QtCore import pyqtSlot, Qt, QModelIndex
-from pydm.PyQt.QtGui import QWidget, QListWidgetItem, QVBoxLayout
+from pydm.PyQt.QtGui import QWidget, QVBoxLayout
 from pydm.widgets.drawing import PyDMDrawingImage
 
 ###########
@@ -19,6 +19,7 @@ from pydm.widgets.drawing import PyDMDrawingImage
 from .func import FunctionPanel
 from .signal import SignalPanel
 from .utils import ui_dir, clean_attr, clean_name
+from .widgets import TyphonSidebarItem
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ class TyphonDisplay(QWidget):
             QPushButton is created
         """
         # Create QListViewItem to store the display information
-        list_item = QListWidgetItem(name)
+        list_item = TyphonSidebarItem(name)
         list_item.setData(Qt.UserRole, display)
         list_widget.addItem(list_item)
         # Add our display to the component widget

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -141,12 +141,27 @@ class TyphonDisplay(QWidget):
             Path to image to display for device
         """
         logger.debug("Creating subdisplay for %s", device.name)
-        self.add_subdisplay(device.name,
-                            DeviceDisplay(device,
-                                          methods=methods,
-                                          image=image,
-                                          parent=self),
-                            button=button)
+        dd = DeviceDisplay(device, **kwargs)
+        # Hide the toolbar from children
+        dd.ui.sidebar.hide()
+        # Do not duplicate the margins around the display
+        dd.ui.widget_layout.setContentsMargins(0, 0, 0, 0)
+        self.add_subdisplay(clean_name(device),
+                            dd, self.ui.component_list)
+
+    def add_tool(self, name, tool):
+        """
+        Add a widget to the toolbar
+
+        Parameters
+        ----------
+        name :str
+            Name of tool to be displayed in sidebar
+
+        tool: QWidget
+            Widget to be added to ``.ui.subdisplay``
+        """
+        self.add_subdisplay(name, tool, self.ui.tool_list)
 
     def add_tab(self, name, widget):
         """
@@ -187,14 +202,7 @@ class TyphonDisplay(QWidget):
         """
         # Find the nested widget for this specific device
         if subdevice:
-            name = subdevice.name
-            try:
-                idx = self.subdisplays[name]
-            except KeyError as exc:
-                raise ValueError("Device %s has not been added to the "
-                                 "DeviceDisplay yet", name) from exc
-            # Add image to widget
-            widget = self.ui.component_widget.widget(idx)
+            widget = self.get_subdisplay(subdevice)
             return widget.add_image(path, subdevice=None)
         # Set existing image file
         logger.debug("Adding an image file %s ...", path)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -82,7 +82,7 @@ class TyphonDisplay(QWidget):
         self.ui.component_list.clicked.connect(
                 self.ui.tool_list.clearSelection)
         # Hide widgets until signals are added to them
-        self.ui.subdisplay.hide()
+        self.ui.subwindow.hide()
         self.method_panel.hide()
         # Create PyDMDrawingImage
         self.image_widget = None
@@ -278,8 +278,8 @@ class TyphonDisplay(QWidget):
         else:
             display = self.get_subdisplay(item)
         # Show our subdisplay if previously hidden
-        if self.ui.subdisplay.isHidden():
-            self.ui.subdisplay.show()
+        if self.ui.subwindow.isHidden():
+            self.ui.subwindow.show()
         # Set the current display
         self.ui.subdisplay.setCurrentWidget(display)
 
@@ -289,7 +289,7 @@ class TyphonDisplay(QWidget):
         Hide the component widget and set all buttons unchecked
         """
         # Hide the main display
-        self.ui.subdisplay.hide()
+        self.ui.subwindow.hide()
         self.ui.component_list.clearSelection()
         self.ui.tool_list.clearSelection()
 

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -81,8 +81,10 @@ class TyphonDisplay(QWidget):
         self.ui.component_list.clicked.connect(self.show_subdisplay)
         self.ui.component_list.clicked.connect(
                 self.ui.tool_list.clearSelection)
-        # Hide widgets until signals are added to them
+        # Hide widgets until objects are added to them
         self.ui.subwindow.hide()
+        self.ui.tool_sidebar.hide()
+        self.ui.component_sidebar.hide()
         self.method_panel.hide()
         # Create PyDMDrawingImage
         self.image_widget = None
@@ -124,9 +126,10 @@ class TyphonDisplay(QWidget):
         # Add our display to the component widget
         self.ui.subdisplay.addWidget(display)
         self.subdisplays[name] = list_item
-        # Show the widgets if hidden
-        if list_widget.isHidden():
-            list_widget.show()
+        # Hide the parent widget if hidden
+        sidebar = list_widget.parent()
+        if sidebar.isHidden():
+            sidebar.show()
 
     def add_subdevice(self, device, **kwargs):
         """

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -59,9 +59,6 @@ class TyphonDisplay(QWidget):
         self.subdisplays = dict()
         # Instantiate UI
         self.ui = uic.loadUi(os.path.join(ui_dir, 'base.ui'), self)
-        self.device_button_group = QButtonGroup()
-        self.device_button_group.addButton(self.ui.hide_button)
-        self.ui.hide_button.clicked.connect(self.hide_subdevices)
         # Set Label Names
         self.ui.name_label.setText(name)
         # Create Panels
@@ -113,24 +110,16 @@ class TyphonDisplay(QWidget):
             QWidget with the PyQtSignal ``clicked``. If None, is given a
             QPushButton is created
         """
-        # Create button
-        if not button:
-            button = QPushButton(self)
-            button.setText(name)
-        # Add the button to the group
-        self.device_button_group.addButton(button)
-        # Add our button to the layout last in the line of buttons
-        # but above the spacer
-        idx = self.ui.buttons.layout().count() - 1
-        self.ui.buttons.layout().insertWidget(idx, button)
-        # Add our display to the widget
-        idx = self.ui.component_widget.addWidget(display)
-        self.subdisplays[name] = idx
-        # Connect button
-        button.clicked.connect(partial(self.show_subdevice, name=name))
+        # Create QListViewItem to store the display information
+        list_item = QListWidgetItem(name)
+        list_item.setData(Qt.UserRole, display)
+        list_widget.addItem(list_item)
+        # Add our display to the component widget
+        self.ui.subdisplay.addWidget(display)
+        self.subdisplays[name] = list_item
         # Show the widgets if hidden
-        if self.ui.buttons.isHidden():
-            self.ui.buttons.show()
+        if list_widget.isHidden():
+            list_widget.show()
 
     def add_subdevice(self, device, methods=None, image=None):
         """

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -21,7 +21,7 @@
   </property>
   <layout class="QHBoxLayout" name="widget_layout">
    <property name="spacing">
-    <number>6</number>
+    <number>10</number>
    </property>
    <property name="sizeConstraint">
     <enum>QLayout::SetFixedSize</enum>
@@ -48,7 +48,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>125</width>
+       <width>150</width>
        <height>16777215</height>
       </size>
      </property>
@@ -68,140 +68,182 @@
       <number>2</number>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QPushButton" name="hide_button">
-          <property name="text">
-           <string>Hide All</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="component_sidebar" native="true">
-          <layout class="QVBoxLayout" name="component_list_layout">
-           <property name="spacing">
-            <number>6</number>
+       <widget class="QWidget" name="sidebar_contents" native="true">
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="leftMargin">
+          <number>2</number>
+         </property>
+         <property name="rightMargin">
+          <number>2</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="hide_button">
+           <property name="text">
+            <string>Hide All</string>
            </property>
-           <property name="leftMargin">
-            <number>1</number>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="component_sidebar" native="true">
+           <layout class="QVBoxLayout" name="component_list_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <property name="leftMargin">
+             <number>1</number>
+            </property>
+            <property name="rightMargin">
+             <number>1</number>
+            </property>
+            <item alignment="Qt::AlignHCenter">
+             <widget class="QLabel" name="component_header">
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: #75767A</string>
+              </property>
+              <property name="text">
+               <string>Components</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QListWidget" name="component_list">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+               </font>
+              </property>
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="verticalScrollBarPolicy">
+               <enum>Qt::ScrollBarAlwaysOff</enum>
+              </property>
+              <property name="horizontalScrollBarPolicy">
+               <enum>Qt::ScrollBarAlwaysOff</enum>
+              </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QAbstractScrollArea::AdjustToContents</enum>
+              </property>
+              <property name="autoScroll">
+               <bool>false</bool>
+              </property>
+              <property name="textElideMode">
+               <enum>Qt::ElideMiddle</enum>
+              </property>
+              <property name="spacing">
+               <number>2</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="tool_sidebar" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <item alignment="Qt::AlignHCenter">
+             <widget class="QLabel" name="tool_header">
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: #75767A</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="text">
+               <string>Tools</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QListWidget" name="tool_list">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+               </font>
+              </property>
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QAbstractScrollArea::AdjustToContents</enum>
+              </property>
+              <property name="autoScroll">
+               <bool>false</bool>
+              </property>
+              <property name="uniformItemSizes">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="stretch_spacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
            </property>
-           <property name="rightMargin">
-            <number>1</number>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
            </property>
-           <item alignment="Qt::AlignHCenter">
-            <widget class="QLabel" name="component_header">
-             <property name="font">
-              <font>
-               <pointsize>10</pointsize>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Components</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QListWidget" name="component_list">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="autoFillBackground">
-              <bool>false</bool>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="verticalScrollBarPolicy">
-              <enum>Qt::ScrollBarAlwaysOff</enum>
-             </property>
-             <property name="horizontalScrollBarPolicy">
-              <enum>Qt::ScrollBarAlwaysOff</enum>
-             </property>
-             <property name="sizeAdjustPolicy">
-              <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-             </property>
-             <property name="autoScroll">
-              <bool>false</bool>
-             </property>
-             <property name="textElideMode">
-              <enum>Qt::ElideMiddle</enum>
-             </property>
-             <property name="spacing">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="tool_sidear" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <property name="spacing">
-            <number>6</number>
-           </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <item alignment="Qt::AlignHCenter">
-            <widget class="QLabel" name="tool_header">
-             <property name="font">
-              <font>
-               <pointsize>10</pointsize>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="text">
-              <string>Tools</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QListWidget" name="tool_list">
-             <property name="autoFillBackground">
-              <bool>false</bool>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="autoScroll">
-              <bool>false</bool>
-             </property>
-             <property name="uniformItemSizes">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <spacer name="stretch_spacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
        <widget class="QFrame" name="vertical_bar">

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -20,6 +20,9 @@
    <string>Form</string>
   </property>
   <layout class="QHBoxLayout" name="widget_layout">
+   <property name="spacing">
+    <number>6</number>
+   </property>
    <property name="sizeConstraint">
     <enum>QLayout::SetFixedSize</enum>
    </property>
@@ -56,7 +59,7 @@
       <string notr="true"/>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="frameShadow">
       <enum>QFrame::Plain</enum>
@@ -64,133 +67,154 @@
      <property name="lineWidth">
       <number>2</number>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="spacing">
-       <number>4</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QPushButton" name="hide_button">
-        <property name="text">
-         <string>Hide All</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="component_sidebar" native="true">
-        <layout class="QVBoxLayout" name="component_list_layout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="leftMargin">
-          <number>1</number>
-         </property>
-         <property name="rightMargin">
-          <number>1</number>
-         </property>
-         <item alignment="Qt::AlignHCenter">
-          <widget class="QLabel" name="component_header">
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Components</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QListWidget" name="component_list">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="autoFillBackground">
-            <bool>false</bool>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="verticalScrollBarPolicy">
-            <enum>Qt::ScrollBarAlwaysOff</enum>
-           </property>
-           <property name="horizontalScrollBarPolicy">
-            <enum>Qt::ScrollBarAlwaysOff</enum>
-           </property>
-           <property name="sizeAdjustPolicy">
-            <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-           </property>
-           <property name="autoScroll">
-            <bool>false</bool>
-           </property>
-           <property name="textElideMode">
-            <enum>Qt::ElideMiddle</enum>
-           </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QPushButton" name="hide_button">
+          <property name="text">
+           <string>Hide All</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="component_sidebar" native="true">
+          <layout class="QVBoxLayout" name="component_list_layout">
            <property name="spacing">
-            <number>2</number>
+            <number>6</number>
            </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+           <property name="leftMargin">
+            <number>1</number>
+           </property>
+           <property name="rightMargin">
+            <number>1</number>
+           </property>
+           <item alignment="Qt::AlignHCenter">
+            <widget class="QLabel" name="component_header">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Components</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="component_list">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="verticalScrollBarPolicy">
+              <enum>Qt::ScrollBarAlwaysOff</enum>
+             </property>
+             <property name="horizontalScrollBarPolicy">
+              <enum>Qt::ScrollBarAlwaysOff</enum>
+             </property>
+             <property name="sizeAdjustPolicy">
+              <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+             </property>
+             <property name="autoScroll">
+              <bool>false</bool>
+             </property>
+             <property name="textElideMode">
+              <enum>Qt::ElideMiddle</enum>
+             </property>
+             <property name="spacing">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="tool_sidear" native="true">
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <item alignment="Qt::AlignHCenter">
+            <widget class="QLabel" name="tool_header">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="text">
+              <string>Tools</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="tool_list">
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="autoScroll">
+              <bool>false</bool>
+             </property>
+             <property name="uniformItemSizes">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="stretch_spacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QWidget" name="tool_sidear" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <item alignment="Qt::AlignHCenter">
-          <widget class="QLabel" name="tool_header">
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="text">
-            <string>Tools</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QListWidget" name="tool_list"/>
-         </item>
-        </layout>
+       <widget class="QFrame" name="vertical_bar">
+        <property name="frameShape">
+         <enum>QFrame::VLine</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>5</number>
+        </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="stretch_spacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>
@@ -345,25 +369,50 @@
      </layout>
     </widget>
    </item>
-   <item alignment="Qt::AlignTop">
-    <widget class="QStackedWidget" name="subdisplay">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item>
+    <widget class="QWidget" name="subwindow" native="true">
+     <property name="baseSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
      </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="lineWidth">
-      <number>0</number>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page"/>
-     <widget class="QWidget" name="page_2"/>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QFrame" name="frame">
+        <property name="frameShape">
+         <enum>QFrame::VLine</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QStackedWidget" name="subdisplay">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <widget class="QWidget" name="page"/>
+        <widget class="QWidget" name="page_2"/>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/typhon/ui/base.ui
+++ b/typhon/ui/base.ui
@@ -35,6 +35,166 @@
    <property name="bottomMargin">
     <number>5</number>
    </property>
+   <item>
+    <widget class="QFrame" name="sidebar">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>125</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>2</number>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="hide_button">
+        <property name="text">
+         <string>Hide All</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="component_sidebar" native="true">
+        <layout class="QVBoxLayout" name="component_list_layout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>1</number>
+         </property>
+         <property name="rightMargin">
+          <number>1</number>
+         </property>
+         <item alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="component_header">
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Components</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QListWidget" name="component_list">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="autoFillBackground">
+            <bool>false</bool>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="verticalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+           </property>
+           <property name="autoScroll">
+            <bool>false</bool>
+           </property>
+           <property name="textElideMode">
+            <enum>Qt::ElideMiddle</enum>
+           </property>
+           <property name="spacing">
+            <number>2</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="tool_sidear" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <item alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="tool_header">
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="text">
+            <string>Tools</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QListWidget" name="tool_list"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="stretch_spacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item alignment="Qt::AlignTop">
     <widget class="QWidget" name="main_widget" native="true">
      <property name="sizePolicy">
@@ -49,7 +209,7 @@
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0">
+     <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,0">
       <property name="spacing">
        <number>5</number>
       </property>
@@ -58,6 +218,12 @@
       </property>
       <item>
        <widget class="QFrame" name="title_frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
         </property>
@@ -163,63 +329,8 @@
         </widget>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item alignment="Qt::AlignTop">
-    <widget class="QFrame" name="buttons">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>2</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>2</number>
-     </property>
-     <property name="midLineWidth">
-      <number>0</number>
-     </property>
-     <layout class="QVBoxLayout" name="button_layout">
-      <property name="sizeConstraint">
-       <enum>QLayout::SetDefaultConstraint</enum>
-      </property>
-      <property name="leftMargin">
-       <number>2</number>
-      </property>
-      <property name="topMargin">
-       <number>2</number>
-      </property>
-      <property name="rightMargin">
-       <number>2</number>
-      </property>
-      <property name="bottomMargin">
-       <number>2</number>
-      </property>
       <item>
-       <widget class="QPushButton" name="hide_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Hide</string>
-        </property>
-        <property name="checkable">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_2">
+       <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -235,12 +346,18 @@
     </widget>
    </item>
    <item alignment="Qt::AlignTop">
-    <widget class="QStackedWidget" name="component_widget">
+    <widget class="QStackedWidget" name="subdisplay">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
      </property>
      <property name="currentIndex">
       <number>0</number>

--- a/typhon/ui/style.qss
+++ b/typhon/ui/style.qss
@@ -36,3 +36,16 @@ QComboBox QAbstractItemView {
 QComboBox:hover {
     border: 2px solid #0b3ae8;
 }
+
+QListWidget::item {
+    bold: False;
+}
+
+QListWidget::item:selected {
+    background-color: #0b3ae8;;
+    color: white;
+}
+
+QListWidget::item:!selected:hover {
+    background-color: #A9A9A9;
+}

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -10,7 +10,7 @@ import os.path
 from pydm.PyQt import uic
 from pydm.PyQt.QtCore import QSize, Qt, pyqtSlot
 from pydm.PyQt.QtGui import QAbstractButton, QStackedWidget, QLabel
-from pydm.PyQt.QtGui import QVBoxLayout, QPushButton, QWidget
+from pydm.PyQt.QtGui import QVBoxLayout, QPushButton, QWidget, QListWidgetItem
 from pydm.widgets import (PyDMDrawingImage, PyDMLabel, PyDMEnumComboBox,
                           PyDMLineEdit)
 ###########
@@ -233,3 +233,12 @@ class RotatingImage(QStackedWidget):
             Image name saved in the :attr:`.images` dictionary
         """
         self.setCurrentIndex(self.images[name])
+
+
+class TyphonSidebarItem(QListWidgetItem):
+    """
+    QListWidgetItem to display in DeviceDisplay sidebar
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setTextAlignment(Qt.AlignCenter)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Revamp the system where we display `Device` components. The goal was:

1) Make the system more extensible for "subdisplays" that were not `ophyd` Devices. These can now be placed in the `Tools` header.
2) Clean the UI to make it look more professional.

This breaks some of the existing API to make functions and widgets have future-proof names

* `component_widget` is now called `subdisplay`
* `device_button_group` has been deprecated
* `add_subdisplay` no longer accepts a custom button type
* `hide_subdevices` is now called `hide_subdisplays` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #27
Closes #56 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a full test of the sidebar logic in `test_subdisplay`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated docstrings

## Screenshots (if appropriate):
![subdisplay](https://user-images.githubusercontent.com/25753048/40940560-0a0cc55c-67fd-11e8-9863-fffcf2374576.gif)
