### PR TITLE
ENH: Signal Abstraction

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -67,10 +67,10 @@ def test_display():
     device.wait_for_connection()
     display = DeviceDisplay(device)
     # We have all our signals
-    shown_read_sigs = list(display.read_panel.pvs.keys())
+    shown_read_sigs = list(display.read_panel.signals.keys())
     assert all([clean_attr(sig) in shown_read_sigs
                 for sig in device.read_attrs])
-    shown_cfg_sigs = list(display.config_panel.pvs.keys())
+    shown_cfg_sigs = list(display.config_panel.signals.keys())
     assert all([clean_attr(sig) in shown_cfg_sigs
                 for sig in device.configuration_attrs])
     # We have all our subdevices

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -32,7 +32,7 @@ def test_panel_creation():
                     # Simulated Signal
                     'Simulated': SynSignal(name='simul'),
                     'SimulatedRO': SynSignalRO(name='simul_ro')})
-    assert len(panel.pvs) == 5
+    assert len(panel.signals) == 5
     # Check read-only channels do not have write widgets
     panel.layout().itemAtPosition(2, 1).layout().count() == 1
     panel.layout().itemAtPosition(4, 1).layout().count() == 1

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -20,7 +20,6 @@ from .conftest import show_widget
 @show_widget
 @using_fake_epics_pv
 def test_panel_creation():
-
     panel = SignalPanel("Test Signals", signals={
                     # Signal is its own write
                     'Standard': EpicsSignal('Tst:Pv'),

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -6,6 +6,7 @@
 # External #
 ############
 from ophyd.signal import EpicsSignal, EpicsSignalRO
+from ophyd.sim import SynSignal, SynSignalRO
 from ophyd.tests.conftest import using_fake_epics_pv
 from pydm.widgets import PyDMEnumComboBox
 
@@ -19,6 +20,7 @@ from .conftest import show_widget
 @show_widget
 @using_fake_epics_pv
 def test_panel_creation():
+
     panel = SignalPanel("Test Signals", signals={
                     # Signal is its own write
                     'Standard': EpicsSignal('Tst:Pv'),
@@ -26,8 +28,18 @@ def test_panel_creation():
                     'Read and Write': EpicsSignal('Tst:Read',
                                                   write_pv='Tst:Write'),
                     # Signal is read-only
-                    'Read Only': EpicsSignalRO('Tst:Pv:RO')})
-    assert len(panel.pvs) == 3
+                    'Read Only': EpicsSignalRO('Tst:Pv:RO'),
+                    # Simulated Signal
+                    'Simulated': SynSignal(name='simul'),
+                    'SimulatedRO': SynSignalRO(name='simul_ro')})
+    assert len(panel.pvs) == 5
+    # Check read-only channels do not have write widgets
+    panel.layout().itemAtPosition(2, 1).layout().count() == 1
+    panel.layout().itemAtPosition(4, 1).layout().count() == 1
+    # Check write widgets are present
+    panel.layout().itemAtPosition(0, 1).layout().count() == 2
+    panel.layout().itemAtPosition(1, 1).layout().count() == 2
+    panel.layout().itemAtPosition(3, 1).layout().count() == 2
     return panel
 
 

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,6 +1,8 @@
-__all__ = ['TyphonDisplay', 'DeviceDisplay', 'use_stylesheet']
+__all__ = ['TyphonDisplay', 'DeviceDisplay', 'use_stylesheet',
+           'register_signal']
 from .display import TyphonDisplay, DeviceDisplay
 from .utils import use_stylesheet
+from .plugins import register_signal
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -89,24 +89,33 @@ class SignalPanel(QWidget):
             `SignalPanel.layout()``
         """
         logger.debug("Adding PV %s", name)
+        # Configure optional write PV settings
+        if write_pv:
+            is_enum = write_pv.enum_strs
+            write_pv = channel_name(write_pv.pvname)
+        else:
+            is_enum = False
+        # Add readback and discovered write PV to grid
+        return self._add_row(channel_name(read_pv.pvname), name,
+                             write=write_pv, is_enum=is_enum)
+
+    def _add_row(self, read, name, write=None, is_enum=False):
         # Create label
         label = QLabel(self)
         label.setText(name)
         # Create signal display
         val_display = QHBoxLayout()
         # Add readback
-        ro = TyphonLabel(init_channel=channel_name(read_pv.pvname),
-                         parent=self)
+        ro = TyphonLabel(init_channel=read, parent=self)
         val_display.addWidget(ro)
         # Add our write_pv if available
-        if write_pv:
-            ch = channel_name(write_pv.pvname)
+        if write:
             # Check whether our device is an enum or not
-            if write_pv.enum_strs:
-                edit = TyphonComboBox(init_channel=ch, parent=self)
+            if is_enum:
+                edit = TyphonComboBox(init_channel=write, parent=self)
             else:
                 logger.debug("Adding LineEdit for %s", name)
-                edit = TyphonLineEdit(init_channel=ch, parent=self)
+                edit = TyphonLineEdit(init_channel=write, parent=self)
             # Add our control widget to layout
             val_display.addWidget(edit)
             # Make sure they share space evenly
@@ -117,5 +126,5 @@ class SignalPanel(QWidget):
         self.layout().addWidget(label, loc, 0)
         self.layout().addLayout(val_display, loc, 1)
         # Store signal
-        self.pvs[name] = (read_pv, write_pv)
+        self.pvs[name] = (read, write)
         return loc

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -92,8 +92,6 @@ class SignalPanel(QWidget):
         # Create label
         label = QLabel(self)
         label.setText(name)
-        label_font = QFont()
-        label.setFont(label_font)
         # Create signal display
         val_display = QHBoxLayout()
         # Add readback

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -38,7 +38,7 @@ class SignalPanel(QWidget):
     def __init__(self, title, signals=None, parent=None):
         super().__init__(parent=parent)
         # Store signal information
-        self.pvs = dict()
+        self.signals = dict()
         # Create panel layout
         self.setLayout(QGridLayout())
         self.layout().setContentsMargins(20, 20, 20, 20)
@@ -142,9 +142,9 @@ class SignalPanel(QWidget):
             val_display.setStretch(0, 1)
             val_display.setStretch(1, 1)
         # Add displays to panel
-        loc = len(self.pvs)
+        loc = len(self.signals)
         self.layout().addWidget(label, loc, 0)
         self.layout().addLayout(val_display, loc, 1)
         # Store signal
-        self.pvs[name] = (read, write)
+        self.signals[name] = (read, write)
         return loc

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -18,11 +18,11 @@ from pydm.PyQt.QtGui import QApplication
 ui_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'ui')
 
 
-def channel_name(pv):
+def channel_name(pv, protocol='ca'):
     """
     Create a valid PyDM channel from a PV name
     """
-    return 'ca://' + pv
+    return protocol + '://' + pv
 
 
 def clean_attr(attr):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`SignalPanel` made the assumption that we would only display `EpicsSignal` objects. After #63 we can now display an `ophyd` Signal. There is also one major API change where we kept the underlying signal mapping of signals to rows that was called `pvs`. This no longer makes sense now that this can contain arbitrary signals. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #43 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
More rigorous testing included in `test_signal` functions.
