### PR TITLE
TST: MockDevice has no EPICS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,6 @@ matrix:
      - python: 3.6
        env: PYDM_CHANNEL=pydm-dev
 
-services:
-  - docker
-
-before_install:
-  - git clone https://github.com/NSLS-II/nsls2-ci --branch master --single-branch ~/ci_scripts
-  - export DOCKER0_IP=$(/sbin/ifconfig docker0 |grep 'inet addr' | sed -e 's/.*addr:\([^ ]*\).*/\1/')
-  - export EPICS_CA_ADDR_LIST=$( echo $DOCKER0_IP | sed -e 's/^\([0-9]\+\)\.\([0-9]\+\)\..*$/\1.\2.255.255/' )
-  - export EPICS_CA_AUTO_ADDR_LIST="no"
-  - export EPICS_CA_MAX_ARRAY_BYTES=10000000
-  - export DOCKERIMAGE="klauer/epics-docker"
-  - export EPICS_BASE=/usr/lib/epics
-  - mkdir /tmp/data
-  - perl --version
-  - docker pull ${DOCKERIMAGE}
-  - docker images
-  - docker run -d -p $DOCKER0_IP:7000-9000:5064/tcp -v /tmp/data:/data ${DOCKERIMAGE}
-  - docker ps -a
-  - ip addr
-
 install:
   - sudo apt-get update
   # Install windows manager

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -83,11 +83,8 @@ def device():
     return MockDevice('Tst:This', name='Simulated Device')
 
 
-@using_fake_epics_pv
 @show_widget
-def test_display():
-    device = MockDevice("Tst:Dev", name="MockDevice")
-    device.wait_for_connection()
+def test_display(device):
     display = DeviceDisplay(device)
     # We have all our signals
     shown_read_sigs = list(display.read_panel.signals.keys())
@@ -104,11 +101,8 @@ def test_display():
     return display
 
 
-@using_fake_epics_pv
 @show_widget
-def test_display_with_funcs():
-    device = MockDevice("Tst:Dev", name="MockDevice")
-    device.wait_for_connection()
+def test_display_with_funcs(device):
     display = DeviceDisplay(device, methods=[device.insert,
                                              device.remove])
     # The method panel is visible
@@ -119,12 +113,9 @@ def test_display_with_funcs():
     return display
 
 
-@using_fake_epics_pv
 @show_widget
-def test_display_with_images(test_images):
+def test_display_with_images(device, test_images):
     (lenna, python) = test_images
-    device = MockDevice("Tst:Dev", name="MockDevice")
-    device.wait_for_connection()
     # Create a display with our image
     display = DeviceDisplay(device, image=lenna)
     assert display.image_widget.filename == lenna
@@ -141,10 +132,8 @@ def test_display_with_images(test_images):
         display.add_image(lenna, subdevice=device)
     return display
 
-@using_fake_epics_pv
 @show_widget
-def test_subdisplay(qapp):
-    device = MockDevice("Tst:Dev", name="MockDevice")
+def test_subdisplay(qapp, device):
     # Set display by Device component
     display = DeviceDisplay(device)
     display.show_subdisplay(device.x)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -5,10 +5,10 @@
 ############
 # External #
 ############
+import numpy as np
+from ophyd import Device, Component as C, FormattedComponent as FC
+from ophyd.sim import SynAxis, Signal, SynPeriodicSignal, SignalRO
 import pytest
-from ophyd.signal import EpicsSignal, EpicsSignalRO
-from ophyd import Device, EpicsMotor, Component as C, FormattedComponent as FC
-from ophyd.tests.conftest import using_fake_epics_pv
 from pydm.PyQt.QtGui import QWidget
 
 ###########
@@ -19,33 +19,50 @@ from typhon.display import DeviceDisplay
 from .conftest import show_widget
 
 
+class ConfiguredSynAxis(SynAxis):
+     velocity = C(Signal, value=100)
+     acceleration = C(Signal, value=10)
+     resolution = C(Signal, value=5)
+     _default_configuration_attrs = ['velocity', 'acceleration']
+
+
+class RandomSignal(SynPeriodicSignal):
+    """
+    Signal that randomly updates a random integer
+    """
+    def __init__(self,*args,  **kwargs):
+        super().__init__(func=lambda: np.random.uniform(0, 100),
+                         period=10, period_jitter=4, **kwargs)
+
+
 class MockDevice(Device):
     # Device signals
-    read1 = C(EpicsSignalRO, ':READ1')
-    read2 = C(EpicsSignalRO, ':READ2')
-    read3 = C(EpicsSignalRO, ':READ3')
-    read4 = C(EpicsSignal,   ':READ4')
-    read5 = C(EpicsSignal,   ':READ5', write_pv=':WRITE5')
-    config1 = C(EpicsSignalRO, ':CFG1')
-    config2 = C(EpicsSignalRO, ':CFG2')
-    config3 = C(EpicsSignalRO, ':CFG3')
-    config4 = C(EpicsSignal,   ':CFG4')
-    config5 = C(EpicsSignal,   ':CFG5', write_pv=':CFGWRITE5')
-    misc1 = C(EpicsSignalRO, ':MISC1')
-    misc2 = C(EpicsSignalRO, ':MISC2')
-    misc3 = C(EpicsSignalRO, ':MISC3')
-    misc4 = C(EpicsSignal,   ':MISC4')
-    misc5 = C(EpicsSignal,   ':MISC5', write_pv=':MISCWRITE5')
+    readback = C(RandomSignal)
+    noise = C(RandomSignal)
+    transmorgifier = C(SignalRO, value=4)
+    setpoint = C(Signal, value=0)
+    velocity = C(Signal, value=1)
+    flux = C(RandomSignal)
+    modified_flux = C(RandomSignal)
+    capacitance = C(RandomSignal)
+    acceleration = C(Signal, value=3)
+    limit = C(Signal, value=4)
+    inductance = C(RandomSignal)
+    transformed_inductance = C(SignalRO, value=3)
+    core_temperature = C(RandomSignal)
+    resolution = C(Signal, value=5)
+    duplicator = C(Signal, value=6)
 
     # Component Motors
-    x = FC(EpicsMotor, 'Tst:MMS:X', name='X Axis')
-    y = FC(EpicsMotor, 'Tst:MMS:Y', name='Y Axis')
-    z = FC(EpicsMotor, 'Tst:MMS:Z', name='Z Axis')
+    x = FC(ConfiguredSynAxis, name='X Axis')
+    y = FC(ConfiguredSynAxis, name='Y Axis')
+    z = FC(ConfiguredSynAxis, name='Z Axis')
 
     # Default Signal Sorting
-    _default_read_attrs = ['read1', 'read2', 'read3', 'read4', 'read5']
-    _default_configuration_attrs = ['config1', 'config2', 'config3',
-                                    'config4', 'config5']
+    _default_read_attrs = ['readback', 'setpoint', 'transmorgifier',
+                           'noise', 'inductance']
+    _default_configuration_attrs = ['flux', 'modified_flux', 'capacitance',
+                                    'velocity', 'acceleration']
 
     def insert(self, width: float=2.0, height: float=2.0,
                fast_mode: bool=False):
@@ -58,7 +75,13 @@ class MockDevice(Device):
 
     @property
     def hints(self):
-        return {'fields': [self.name+'_read1']}
+        return {'fields': [self.name+'_readback']}
+
+
+@pytest.fixture(scope='function')
+def device():
+    return MockDevice('Tst:This', name='Simulated Device')
+
 
 @using_fake_epics_pv
 @show_widget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Test with fully simulated `ophyd` Device. Added some signals that update randomly in the background. Makes it surprisingly fun to plot stuff. We have also rid ourselves of the `using_fake_epics_pv` race conditions! Also no longer need the Docker container. Not sure we ever really needed it to be honest.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #67 
