### PR TITLE
FIX: Extra SignalPlugin features

### DIFF
--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -130,8 +130,14 @@ class SignalConnection(PyDMConnection):
             # Report as connected
             self.write_access_signal.emit(True)
             self.connection_state_signal.emit(True)
+            # Report as no-alarm state
             self.new_severity_signal.emit(0)
+            # Report the current value
             self.send_new_value(value=self.signal.get())
+            # Report the precision
+            prec = self.signal.describe()[self.signal.name].get('precision')
+            if prec:
+                self.prec_signal.emit(prec)
             # If the channel is used for writing to PVs, hook it up to the
             # 'put' methods.
             if channel.value_signal is not None:

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -130,6 +130,7 @@ class SignalConnection(PyDMConnection):
             # Report as connected
             self.write_access_signal.emit(True)
             self.connection_state_signal.emit(True)
+            self.new_severity_signal.emit(0)
             self.send_new_value(value=self.signal.get())
             # If the channel is used for writing to PVs, hook it up to the
             # 'put' methods.

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -42,6 +42,7 @@ def clean_attr(attr):
     """
     Create a nicer, human readable alias from a Python attribute name
     """
+    attr = attr.replace('.', '_')
     return ' '.join([word[0].upper() + word[1:] for word in attr.split('_')])
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* We should be able to get the `"precision"`from the description of the signal. This is then communicated to the widget through the `precision_signal`.
* Before https://github.com/slaclab/pydm/issues/282 is resolved we need to set the alarm state to avoid a `"Disconnected"` border.
* One minor improvement to the `clean_attr` functions to deal with attributes that have `.` in them still

<!--
## Screenshots (if appropriate):
-->
