### PR TITLE
FIX: Show child signals in plot

### DIFF
--- a/typhon/ui/plot.ui
+++ b/typhon/ui/plot.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>534</width>
-    <height>604</height>
+    <height>611</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -95,7 +95,11 @@
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="signal_combo"/>
+       <widget class="QComboBox" name="signal_combo">
+        <property name="insertPolicy">
+         <enum>QComboBox::InsertAlphabetically</enum>
+        </property>
+       </widget>
       </item>
       <item>
        <spacer name="horizontalSpacer_4">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Before we only displayed the signals associated with the highest level device as available in `DeviceTimePlot`. This PR now adds the child signals so they can be plotted as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #79 


## Screenshots (if appropriate):
![sigs](https://user-images.githubusercontent.com/25753048/41609879-9fe57264-73a0-11e8-81b6-6565eb2fde0a.png)

