### PR TITLE
ENH: Official support for QDarkStyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
      - python: 3.6
        env:
           - BUILD=1
-          - PYDM_CHANNEL=pydm-tag
+          - PYDM_CHANNEL=pcds-tag
      - python: 3.6
        env: PYDM_CHANNEL=pydm-dev
 
@@ -29,8 +29,7 @@ install:
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
   - conda config --add channels $PYDM_CHANNEL 
-  - conda config --append channels pydm-tag
-  - conda config --append channels lightsource2-tag
+  - conda config --append channels pcds-tag
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ information to craft user interfaces.
 ## Installation
 Recommended installation:
 ```
-conda install typhon -c pcds-tag -c pydm-tag -c lightsource2-tag -c conda-forge
+conda install typhon -c pcds-tag -c conda-forge
 ```
 All `-tag` channels have `-dev` counterparts for bleeding edge installations.
 Both `requirements.txt` and optional `dev-requirements.txt` are kept up to date

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,6 +16,7 @@ requirements:
       - python
       - pydm >=1.2.0
       - ophyd >=1.2.0
+      - qdarkstyle
 
 test:
     imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/slaclab/pydm.git
 git+https://github.com/NSLS-II/ophyd.git
+git+https://github.com/pcdshub/QDarkStyleSheet.git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,7 @@ def qapp(pytestconfig):
         pass
     else:
         application = PyDMApplication(use_main_window=False)
-        if pytestconfig.getoption('--dark'):
-            import qdarkstyle
-            application.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
-        else:
-            typhon.use_stylesheet()
+        typhon.use_stylesheet(pytestconfig.getoption('--dark'))
     return application
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,3 +3,4 @@ from typhon.utils import use_stylesheet
 
 def test_stylesheet():
     use_stylesheet()
+    use_stylesheet(dark=True)

--- a/typhon/ui/style.qss
+++ b/typhon/ui/style.qss
@@ -37,10 +37,6 @@ QComboBox:hover {
     border: 2px solid #0b3ae8;
 }
 
-QListWidget::item {
-    bold: False;
-}
-
 QListWidget::item:selected {
     background-color: #0b3ae8;;
     color: white;

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -65,19 +65,33 @@ def clean_name(device, strip_parent=True):
     return clean_attr(name)
 
 
-def use_stylesheet():
+def use_stylesheet(dark=False):
     """
     Use the Typhon stylesheet
+
+    Parameters
+    ----------
+    dark: bool, optional
+        Whether or not to use the QDarkStyleSheet theme. By default the light
+        theme is chosen.
     """
-    # Load the path to the file
-    style_path = os.path.join(ui_dir, 'style.qss')
-    if not os.path.exists(style_path):
-        raise EnvironmentError("Unable to find Typhon stylesheet in {}"
-                               "".format(style_path))
-    # Load the stylesheet from the file
-    with open(style_path, 'r') as handle:
-        app = QApplication.instance()
-        app.setStyleSheet(handle.read())
+    # Dark Style
+    if dark:
+        import qdarkstyle
+        style = qdarkstyle.load_stylesheet_pyqt5()
+    # Light Style
+    else:
+        # Load the path to the file
+        style_path = os.path.join(ui_dir, 'style.qss')
+        if not os.path.exists(style_path):
+            raise EnvironmentError("Unable to find Typhon stylesheet in {}"
+                                   "".format(style_path))
+        # Load the stylesheet from the file
+        with open(style_path, 'r') as handle:
+            style = handle.read()
+    # Set stylesheet
+    app = QApplication.instance()
+    app.setStyleSheet(style)
 
 
 def random_color():

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -11,7 +11,7 @@ import random
 # External #
 ############
 from ophyd.signal import EpicsSignalBase
-from pydm.PyQt.QtGui import QApplication, QColor
+from pydm.PyQt.QtGui import QApplication, QColor, QStyleFactory
 
 #############
 #  Package  #
@@ -89,8 +89,11 @@ def use_stylesheet(dark=False):
         # Load the stylesheet from the file
         with open(style_path, 'r') as handle:
             style = handle.read()
-    # Set stylesheet
+    # Find application
     app = QApplication.instance()
+    # Set Fusion style
+    app.setStyle(QStyleFactory.create('Fusion'))
+    # Set Stylesheet
     app.setStyleSheet(style)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`QDarkStyleSheet` is now packaged with the repository. It was used in the tests before but never anywhere in the actual library. Since this is now built on the `pcds-tag` channel I feel comfortable making it an actual dependency. To use the stylesheet I added a `dark` optional keyword on `typhon.use_stylesheet`. This allows a convenient way to load the stylesheet into your application. 

### Other small changes
* I also fixed an error in the light stylesheet that raised a warning about `bold` not being an .  
  available option on `QListWidget::item`. 

* Since our standard PCDS environment uses the `conda-forge` builds of `ophyd` and `bluesky` I removed the `lightsource2-tag` channel from all tests. 


