### PR TITLE
DEP: Remove unused Title Argument

### DIFF
--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -20,7 +20,7 @@ from .conftest import show_widget
 @show_widget
 @using_fake_epics_pv
 def test_panel_creation():
-    panel = SignalPanel("Test Signals", signals={
+    panel = SignalPanel(signals={
                     # Signal is its own write
                     'Standard': EpicsSignal('Tst:Pv'),
                     # Signal has separate write/read
@@ -45,7 +45,7 @@ def test_panel_creation():
 @show_widget
 @using_fake_epics_pv
 def test_panel_add_enum():
-    panel = SignalPanel("Test Signals")
+    panel = SignalPanel()
     # Create an enum pv
     sig = EpicsSignal("Tst:Enum")
     sig._write_pv.enum_strs = ('A', 'B')

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -66,9 +66,9 @@ class TyphonDisplay(QWidget):
         self.ui.name_label.setText(name)
         # Create Panels
         self.method_panel = FunctionPanel(parent=self)
-        self.read_panel = SignalPanel("Read", parent=self)
-        self.config_panel = SignalPanel("Configuration", parent=self)
-        self.misc_panel = SignalPanel("Miscellaneous", parent=self)
+        self.read_panel = SignalPanel(parent=self)
+        self.config_panel = SignalPanel(parent=self)
+        self.misc_panel = SignalPanel(parent=self)
         # Add all the panels
         self.ui.main_layout.insertWidget(2, self.read_panel,
                                          0, Qt.AlignHCenter)

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -10,6 +10,7 @@ from ophyd.signal import EpicsSignalBase
 from ophyd.sim import SignalRO
 from pydm.PyQt.QtCore import QSize
 from pydm.PyQt.QtGui import QHBoxLayout, QLabel, QWidget, QGridLayout
+from warnings import warn
 
 #############
 #  Package  #
@@ -27,17 +28,18 @@ class SignalPanel(QWidget):
 
     Parameters
     ----------
-    title : str
-        Title for hide button
-
     signals : OrderedDict, optional
         Signals to include in the panel
 
     parent : QWidget, optional
         Parent of panel
     """
-    def __init__(self, title, signals=None, parent=None):
+    def __init__(self, title=None, signals=None, parent=None):
         super().__init__(parent=parent)
+        # Title is no longer supported
+        if title:
+            warn("The 'title' option for SignalPanel is deprecated. "
+                 "It will be removed in future releases.")
         # Store signal information
         self.signals = dict()
         # Create panel layout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Noticed today that we require `title` as an argument of `SignalPanel` but we then just drop it on the ground. I will remove this in a future release but I have pledged a level of stability so I'll mark it as deprecated for this release, then remove it the one following.

For now, we warn and any internal usage of "title" in `typhon` has been removed.