### PR TITLE
MAINT: Catch exceptions created on Subscription

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: false
+sudo: required
 
 env:
   global:

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -175,3 +175,15 @@ class SignalPlugin(PyDMPlugin):
     """Plugin registered with PyDM to handle SignalConnection"""
     protocol = 'sig'
     connection_class = SignalConnection
+
+    def add_connection(self, channel):
+        """Add a connection to a channel"""
+        try:
+            # Add a PyDMConnection for the channel
+            super().add_connection(channel)
+        # There is a chance that we raise an Exception on subscription. If so,
+        # don't add this to our list of good to go exceptions so the next
+        # attempt we try again.
+        except Exception:
+            logger.exception("Unable to create a connection to %r",
+                             channel)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Ran into an `ophyd.Signal` that raised an exception upon subscription.  The `SignalPlugin` did not wrap `subscribe` up in a `try / except` block which brought everything to a screeching halt.

Now, the solution is not quite so simple as just adding the `try` block in `SignalConnection`. If we raise an error on subscription we **want** that `SignalConnection` to explode. Otherwise we run the risk of subscribing a bunch of channels to a connection that will never update! So instead my solution was to add this to the `add_connection` block. If we fail to subscribe we make sure not to save the `SignalConnection` and the next channel that needs the `signal` will try again.

@hhslepicka Does this belong in PyDM? Or are `PyDMPlugin` objects responsible for catching their own kind of exceptions? 


