### PR TITLE
ENH: Signal Metadata

### DIFF
--- a/docs/source/connections.rst
+++ b/docs/source/connections.rst
@@ -28,6 +28,22 @@ plugin.
    # This signal is now available for use with PyDM widgets
    PyDMWidget(channel='sig://this_signal')
 
-
 Note that this is all done for you if you use the :class:`.SignalPanel`, but
 maybe useful if you would like to use the :class:`.SignalPlugin` directly.
+
+Inclusion of Metadata
+---------------------
+In many cases just knowing the value of a signal is not enough to accurately
+display it. Extra pieces of information such as the units and precision of
+information can provide a richer operator experience. ``Typhon`` counts on this
+information being available in the output of ``describe`` method of the signal.
+If you want your child ``ophyd.Signal`` class to convey this information make
+sure that it is expressed properly in the output of ``describe``.
+
+===================== ===============
+Metadata              Description Key
+===================== ===============
+Precision             `"precision"`
+Enumeration Strings   `"enum_strs"`
+Engineering Units     `"units"`
+===================== ===============

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from functools import wraps
 ############
 import pytest
 import ophyd.sim
+from ophyd import Signal
 from pydm import PyDMApplication
 
 ###########
@@ -80,3 +81,14 @@ def motor():
     for sig in ophyd.sim.motor.component_names:
         typhon.register_signal(getattr(ophyd.sim.motor, sig))
     return ophyd.sim.motor
+
+
+
+class RichSignal(Signal):
+
+    def describe(self):
+        return {self.name : {'enum_strs': ('a', 'b', 'c'),
+                             'precision': 2,
+                             'units': 'urad',
+                             'dtype': 'number',
+                             'shape': []}}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -10,6 +10,15 @@ class WritableWidget(QWidget, PyDMWritableWidget):
     pass
 
 
+class RichSignal(Signal):
+
+    def describe(self):
+        return {self.name : {'enum_strs': ('a', 'b', 'c'),
+                             'precision': 2,
+                             'units': 'urad',
+                             'dtype': 'number',
+                             'shape': []}}
+
 def test_signal_connection(qapp):
     # Create a signal and attach our listener
     sig = Signal(name='my_signal', value=1)
@@ -50,3 +59,17 @@ def test_invalid_signal():
     sig_conn = SignalConnection(listener, 'my_signal')
     assert not widget._connected
     assert not widget._write_access
+
+
+def test_metadata(qapp):
+    widget = WritableWidget()
+    listener = widget.channels()[0]
+    # Create a signal and attach our listener
+    sig = RichSignal(name='md_signal', value=1)
+    register_signal(sig)
+    sig_conn = SignalConnection(listener, 'md_signal')
+    qapp.processEvents()
+    # Check that metadata the metadata got there
+    assert widget.enum_strings == ('a', 'b', 'c')
+    assert widget._unit == 'urad'
+    assert widget._prec == 2

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -19,6 +19,15 @@ class RichSignal(Signal):
                              'dtype': 'number',
                              'shape': []}}
 
+class DeadSignal(Signal):
+
+    def get(self, *args, **kwargs):
+        raise TimeoutError("Timeout on get")
+
+    def describe(self, *args, **kwargs):
+        raise TimeoutError("Timeout on describe")
+
+
 def test_signal_connection(qapp):
     # Create a signal and attach our listener
     sig = Signal(name='my_signal', value=1)
@@ -73,3 +82,15 @@ def test_metadata(qapp):
     assert widget.enum_strings == ('a', 'b', 'c')
     assert widget._unit == 'urad'
     assert widget._prec == 2
+
+
+def test_disconnection(qapp):
+    widget = WritableWidget()
+    listener = widget.channels()[0]
+    # Create a signal and attach our listener
+    sig = DeadSignal(name='broken_signal', value=1)
+    register_signal(sig)
+    sig_conn = SignalConnection(listener, 'broken_signal')
+    sig_conn.add_listener(sig_b)
+    assert not widget._connected
+    assert not widget._write_access

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,19 +5,13 @@ from pydm.PyQt.QtGui import QWidget
 from typhon.plugins.core import (SignalPlugin, SignalConnection,
                                  register_signal)
 
+from .conftest import RichSignal
+
+
 class WritableWidget(QWidget, PyDMWritableWidget):
     """Simple Testing Widget"""
     pass
 
-
-class RichSignal(Signal):
-
-    def describe(self):
-        return {self.name : {'enum_strs': ('a', 'b', 'c'),
-                             'precision': 2,
-                             'units': 'urad',
-                             'dtype': 'number',
-                             'shape': []}}
 
 class DeadSignal(Signal):
     subscribable = False

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -5,7 +5,7 @@
 ############
 # External #
 ############
-from ophyd.signal import EpicsSignal, EpicsSignalRO
+from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
 from ophyd.sim import SynSignal, SynSignalRO
 from ophyd.tests.conftest import using_fake_epics_pv
 from pydm.widgets import PyDMEnumComboBox
@@ -14,7 +14,7 @@ from pydm.widgets import PyDMEnumComboBox
 # Package #
 ###########
 from typhon.signal import SignalPanel
-from .conftest import show_widget
+from .conftest import show_widget, RichSignal
 
 
 @show_widget
@@ -50,8 +50,7 @@ def test_panel_add_enum():
     epics_sig = EpicsSignal("Tst:Enum")
     epics_sig._write_pv.enum_strs = ('A', 'B')
     # Create an enum signal
-    syn_sig = SynSignal(name='Syn:Enum')
-    syn_sig.enum_strs = ('C', 'D')
+    syn_sig = RichSignal(name='Syn:Enum', value=1)
     # Add our signals to the panel
     loc1 = panel.add_signal(epics_sig, "EPICS Enum PV")
     loc2 = panel.add_signal(syn_sig, "Sim Enum PV")

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -47,13 +47,22 @@ def test_panel_creation():
 def test_panel_add_enum():
     panel = SignalPanel()
     # Create an enum pv
-    sig = EpicsSignal("Tst:Enum")
-    sig._write_pv.enum_strs = ('A', 'B')
-    # Add our signal to the panel
-    loc = panel.add_signal(sig, "Enum PV")
+    epics_sig = EpicsSignal("Tst:Enum")
+    epics_sig._write_pv.enum_strs = ('A', 'B')
+    # Create an enum signal
+    syn_sig = SynSignal(name='Syn:Enum')
+    syn_sig.enum_strs = ('C', 'D')
+    # Add our signals to the panel
+    loc1 = panel.add_signal(epics_sig, "EPICS Enum PV")
+    loc2 = panel.add_signal(syn_sig, "Sim Enum PV")
     # Check our signal was added a QCombobox
     # Assume it is the last item in the button layout
-    but_layout = panel.layout().itemAtPosition(loc, 1)
+    but_layout = panel.layout().itemAtPosition(loc1, 1)
+    assert isinstance(but_layout.itemAt(but_layout.count()-1).widget(),
+                      PyDMEnumComboBox)
+    # Check our signal was added a QCombobox
+    # Assume it is the last item in the button layout
+    but_layout = panel.layout().itemAtPosition(loc2, 1)
     assert isinstance(but_layout.itemAt(but_layout.count()-1).widget(),
                       PyDMEnumComboBox)
     return panel

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -121,7 +121,7 @@ class SignalConnection(PyDMConnection):
         self.new_severity_signal.emit(0)
         try:
             # Gather the current value
-            signal_val =self.signal.get()
+            signal_val = self.signal.get()
             # Gather metadata
             signal_desc = self.signal.describe()[self.signal.name]
         except Exception:
@@ -132,7 +132,7 @@ class SignalConnection(PyDMConnection):
         # Report as connected
         self.write_access_signal.emit(True)
         self.connection_state_signal.emit(True)
-        # Report new value 
+        # Report new value
         self.send_new_value(signal_val)
         # Report metadata
         for (field, signal) in (

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -61,19 +61,11 @@ class SignalConnection(PyDMConnection):
         # Create base connection
         super().__init__(channel, address, protocol=protocol, parent=parent)
         self.signal_type = None
-        # Get Signal from registry
-        try:
-            self.signal = signal_registry[address]
-        except KeyError as exc:
-            logger.exception("Unable to find signal %s in signal registry."
-                             "Use typhon.plugins.register_signal()",
-                             address)
-            # Report as disconnected
-            self.signal = None
-        else:
-            # Subscribe to updates from Ophyd
-            self.signal.subscribe(self.send_new_value,
-                                  event_type=self.signal.SUB_VALUE)
+        # Collect our signal
+        self.signal = signal_registry[address]
+        # Subscribe to updates from Ophyd
+        self.signal.subscribe(self.send_new_value,
+                              event_type=self.signal.SUB_VALUE)
         # Add listener
         self.add_listener(channel)
 
@@ -125,39 +117,43 @@ class SignalConnection(PyDMConnection):
         """
         # Perform the default connection setup
         super().add_listener(channel)
-        # Send the most recent value to the channel
-        if self.signal:
-            # Report as connected
-            self.write_access_signal.emit(True)
-            self.connection_state_signal.emit(True)
-            # Report as no-alarm state
-            self.new_severity_signal.emit(0)
-            # Report the current value
-            self.send_new_value(value=self.signal.get())
-            # Report metadata
+        # Report as no-alarm state
+        self.new_severity_signal.emit(0)
+        try:
+            # Gather the current value
+            signal_val =self.signal.get()
+            # Gather metadata
             signal_desc = self.signal.describe()[self.signal.name]
-            for (field, signal) in (
-                            ('precision', self.prec_signal),
-                            ('enum_strs', self.enum_strings_signal),
-                            ('units', self.unit_signal)):
-                # Check if we have metadata to send for field
-                val = signal_desc.get(field)
-                # If so emit it to our listeners
-                if val:
-                    signal.emit(val)
-            # If the channel is used for writing to PVs, hook it up to the
-            # 'put' methods.
-            if channel.value_signal is not None:
-                for _typ in self.supported_types:
-                    try:
-                        val_sig = channel.value_signal[_typ]
-                        val_sig.connect(self.put_value, Qt.QueuedConnection)
-                    except KeyError:
-                        logger.debug("%s has no value_signal for type %s",
-                                     channel.address, _typ)
-        else:
-            self.write_access_signal.emit(False)
-            self.connection_state_signal.emit(False)
+        except Exception:
+            logger.exception("Failed to gather proper information "
+                             "from signal %r to initialize %r",
+                             self.signal.name, channel)
+            return
+        # Report as connected
+        self.write_access_signal.emit(True)
+        self.connection_state_signal.emit(True)
+        # Report new value 
+        self.send_new_value(signal_val)
+        # Report metadata
+        for (field, signal) in (
+                    ('precision', self.prec_signal),
+                    ('enum_strs', self.enum_strings_signal),
+                    ('units', self.unit_signal)):
+            # Check if we have metadata to send for field
+            val = signal_desc.get(field)
+            # If so emit it to our listeners
+            if val:
+                signal.emit(val)
+        # If the channel is used for writing to PVs, hook it up to the
+        # 'put' methods.
+        if channel.value_signal is not None:
+            for _typ in self.supported_types:
+                try:
+                    val_sig = channel.value_signal[_typ]
+                    val_sig.connect(self.put_value, Qt.QueuedConnection)
+                except KeyError:
+                    logger.debug("%s has no value_signal for type %s",
+                                 channel.address, _typ)
 
     def remove_listener(self, channel):
         """
@@ -188,9 +184,13 @@ class SignalPlugin(PyDMPlugin):
         try:
             # Add a PyDMConnection for the channel
             super().add_connection(channel)
-        # There is a chance that we raise an Exception on subscription. If so,
-        # don't add this to our list of good to go exceptions so the next
+        # There is a chance that we raise an Exception on creation. If so,
+        # don't add this to our list of good to go connections. The next
         # attempt we try again.
+        except KeyError:
+            logger.error("Unable to find signal for %r in signal registry."
+                         "Use typhon.plugins.register_signal()",
+                         channel)
         except Exception:
             logger.exception("Unable to create a connection to %r",
                              channel)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -134,10 +134,17 @@ class SignalConnection(PyDMConnection):
             self.new_severity_signal.emit(0)
             # Report the current value
             self.send_new_value(value=self.signal.get())
-            # Report the precision
-            prec = self.signal.describe()[self.signal.name].get('precision')
-            if prec:
-                self.prec_signal.emit(prec)
+            # Report metadata
+            signal_desc = self.signal.describe()[self.signal.name]
+            for (field, signal) in (
+                            ('precision', self.prec_signal),
+                            ('enum_strs', self.enum_strings_signal),
+                            ('units', self.unit_signal)):
+                # Check if we have metadata to send for field
+                val = signal_desc.get(field)
+                # If so emit it to our listeners
+                if val:
+                    signal.emit(val)
             # If the channel is used for writing to PVs, hook it up to the
             # 'put' methods.
             if channel.value_signal is not None:

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -90,12 +90,21 @@ class SignalPanel(QWidget):
             # Check read-only
             if isinstance(signal, SignalRO):
                 write = None
+                is_enum = False
             else:
                 write = channel_name(signal.name, protocol='sig')
+                try:
+                    is_enum = signal.describe()[signal.name].get('enum_strs',
+                                                                 False)
+                except Exception:
+                    is_enum = False
+                    logger.exception("Unable to check if %r is an enum",
+                                     signal.name)
             # Add signal row
             return self._add_row(channel_name(signal.name,
                                               protocol='sig'),
-                                 name, write=write)
+                                 name, write=write,
+                                 is_enum=is_enum)
 
     def add_pv(self, read_pv, name, write_pv=None):
         """

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -127,11 +127,16 @@ class SignalPanel(QWidget):
         """
         logger.debug("Adding PV %s", name)
         # Configure optional write PV settings
+        is_enum = False
         if write_pv:
-            is_enum = write_pv.enum_strs
-            write_pv = channel_name(write_pv.pvname)
-        else:
-            is_enum = False
+            try:
+                is_enum = write_pv.enum_strs
+            except Exception:
+                logger.exception("Unable to determine if %r is an enum",
+                                 write_pv)
+                is_enum = False
+            finally:
+                write_pv = channel_name(write_pv.pvname)
         # Add readback and discovered write PV to grid
         return self._add_row(channel_name(read_pv.pvname), name,
                              write=write_pv, is_enum=is_enum)

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -154,6 +154,7 @@ class SignalPanel(QWidget):
         if write:
             # Check whether our device is an enum or not
             if is_enum:
+                logger.debug("Adding Combobox for %s", name)
                 edit = TyphonComboBox(init_channel=write, parent=self)
             else:
                 logger.debug("Adding LineEdit for %s", name)

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -93,6 +93,10 @@ class TyphonLineEdit(PyDMLineEdit):
     """
     Reimplementation of PyDMLineEdit to set some custom defaults
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.showUnits = True
+
     def sizeHint(self):
         return QSize(100, 30)
 
@@ -104,6 +108,7 @@ class TyphonLabel(PyDMLabel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setAlignment(Qt.AlignCenter)
+        self.showUnits = True
 
     def sizeHint(self):
         return QSize(100, 30)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Some general improvements to the `SignalPlugin`

* We now inspect the `describe` dictionary of the `Signal` for `"enum_strs"`, `"units"` and `"precision"`. I also left this pretty extensible so that in the future as long as we have a describe key that maps to a signal it is just a matter of adding a tuple. 
* Very much the successor to #91, there was the potential for exceptions on `get` when setting up our signal that would not have been caught. We now wrap these up nicely. Also now that `SignalPlugin` handles some of the error handling I moved more things there. It makes more sense to not create a `SignalConnection` at all if you give me the name of a non-existant `Signal`.

### Concerns
There is still the potential for a few strange edge cases to arise if our network is unstable. For instance if we successfully subscribe to a signal, but then fail to get it e.t.c. I can try and armor this Plugin up against all these situations but the real root of the issue is that the base `Signal` has not callback for connection. I'm kind of left guessing if my last `get` failed because of a hiccup or because my signal is really gone.

Also @hhslepicka I am assuming I don't have to be diligent about sending the connection state to `False`. Is this true? Widgets will default to their disconnected state? I ask because I don't want one bad `get` to mark every listener as disconnected....

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #85 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added a test to send `metadata` through describe
* Add a test with a signal that raises `TimeoutError`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- [x] Add notes on how signal picks up metadata 