### PR TITLE
MAINT: QtPy Interface

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,9 +14,9 @@ requirements:
 
     run:
       - python
-      - pydm >=1.2.0
       - numpy
       - ophyd >=1.2.0
+      - pydm >=1.2.0
       - qdarkstyle
       - qtpy
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     run:
       - python
       - pydm >=1.2.0
+      - numpy
       - ophyd >=1.2.0
       - qdarkstyle
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
       - numpy
       - ophyd >=1.2.0
       - qdarkstyle
+      - qtpy
 
 test:
     imports:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
+codecov
+doctr
+flake8
+ipython
+matplotlib
 pytest
 pytest-timeout
-codecov
-matplotlib
-ipython
-flake8
 sphinx
 sphinx_rtd_theme
-doctr

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/slaclab/pydm.git
 git+https://github.com/NSLS-II/ophyd.git
 git+https://github.com/pcdshub/QDarkStyleSheet.git
 numpy
+qtpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/slaclab/pydm.git
 git+https://github.com/NSLS-II/ophyd.git
 git+https://github.com/pcdshub/QDarkStyleSheet.git
+numpy

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -9,7 +9,7 @@ import numpy as np
 from ophyd import Device, Component as C, FormattedComponent as FC
 from ophyd.sim import SynAxis, Signal, SynPeriodicSignal, SignalRO
 import pytest
-from pydm.PyQt.QtGui import QWidget
+from qtpy.QtWidgets import QWidget
 
 ###########
 # Package #

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -82,4 +82,4 @@ def test_device_plot(motor):
     # Add the hint
     assert len(dtp.ui.timeplot.curves) == 1
     # Added all the signals
-    assert dtp.ui.signal_combo.count() == 2
+    assert dtp.ui.signal_combo.count() == len(motor.component_names)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -10,9 +10,9 @@ import logging
 # Third Party #
 ###############
 from ophyd import EpicsSignal, Signal
-from pydm.PyQt.QtGui import QColor
-from pydm.PyQt.QtCore import Qt
 import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
 
 ##########
 # Module #

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,11 +1,21 @@
+############
+# Standard #
+############
+
+############
+# External #
+############
 from ophyd import Signal
 from pydm.widgets.base import PyDMWritableWidget
-from pydm.PyQt.QtGui import QWidget
+from qtpy.QtWidgets import QWidget
 
+###########
+# Package #
+###########
+from .conftest import DeadSignal, RichSignal
 from typhon.plugins.core import (SignalPlugin, SignalConnection,
                                  register_signal)
 
-from .conftest import DeadSignal, RichSignal
 
 
 class WritableWidget(QWidget, PyDMWritableWidget):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -1,18 +1,18 @@
 ############
 # Standard #
 ############
-import os.path
 import logging
-from ophyd import Device
+import os.path
 
 ############
 # External #
 ############
-from pydm.PyQt import uic
-from pydm.PyQt.QtCore import pyqtSlot, Qt, QModelIndex
-from pydm.PyQt.QtGui import QScrollArea, QWidget
+from ophyd import Device
 from pydm.widgets.drawing import PyDMDrawingImage
 from pydm.widgets.logdisplay import PyDMLogDisplay
+from qtpy import uic
+from qtpy.QtCore import Slot, Qt, QModelIndex
+from qtpy.QtWidgets import QScrollArea, QWidget
 
 ###########
 # Package #
@@ -270,8 +270,8 @@ class TyphonDisplay(QWidget):
             display = clean_name(display)
         return self._item_from_sidebar(display).data(Qt.UserRole)
 
-    @pyqtSlot(str)
-    @pyqtSlot(QModelIndex)
+    @Slot(str)
+    @Slot(QModelIndex)
     def show_subdisplay(self, item):
         """
         Show subdevice display of the QStackedWidget
@@ -292,7 +292,7 @@ class TyphonDisplay(QWidget):
         self.ui.subdisplay.setCurrentWidget(display)
         self.ui.subdisplay.setFixedWidth(display.sizeHint().width())
 
-    @pyqtSlot()
+    @Slot()
     def hide_subdisplays(self):
         """
         Hide the component widget and set all buttons unchecked
@@ -341,7 +341,6 @@ class DeviceDisplay(TyphonDisplay):
             if attr not in self.device._sub_devices:
                 self.read_panel.add_signal(getattr(self.device, attr),
                                            clean_attr(attr))
-
         for attr in self.device.configuration_attrs:
             if attr not in self.device._sub_devices:
                 self.config_panel.add_signal(getattr(self.device, attr),

--- a/typhon/func.py
+++ b/typhon/func.py
@@ -23,10 +23,11 @@ from functools import partial
 # External #
 ############
 import numpy as np
-from pydm.PyQt.QtCore import pyqtSlot, Qt, QSize
-from pydm.PyQt.QtGui import QSizePolicy, QFont, QGroupBox, QHBoxLayout, QLabel
-from pydm.PyQt.QtGui import QSpacerItem, QWidget, QPushButton
-from pydm.PyQt.QtGui import QLineEdit, QVBoxLayout, QCheckBox
+from qtpy.QtCore import Slot, Qt, QSize
+from qtpy.QtGui import QFont
+from qtpy.QtWidgets import (QSizePolicy, QGroupBox, QLabel, QSpacerItem,
+                            QWidget, QPushButton, QLineEdit, QCheckBox,
+                            QHBoxLayout, QVBoxLayout)
 
 ###########
 # Package #
@@ -281,7 +282,7 @@ class FunctionDisplay(QGroupBox):
         return [param.parameter for param in self.param_controls
                 if parameters[param.parameter].default != inspect._empty]
 
-    @pyqtSlot()
+    @Slot()
     def execute(self):
         """
         Execute :attr:`.func`

--- a/typhon/plot.py
+++ b/typhon/plot.py
@@ -12,9 +12,10 @@ from functools import partial
 ###############
 # Third Party #
 ###############
-from pydm.PyQt import uic
-from pydm.PyQt.QtGui import QApplication, QWidget, QBrush
-from pydm.PyQt.QtCore import Qt, pyqtSlot
+from qtpy import uic
+from qtpy.QtCore import Qt, Slot
+from qtpy.QtGui import QBrush
+from qtpy.QtWidgets import QApplication, QWidget
 
 ##########
 # Module #
@@ -52,7 +53,7 @@ class TyphonTimePlot(QWidget):
     configure the plotted signals. The list of signals available to the
     operator can be controlled via :meth:`.add_available_signal`. Shortcuts can
     be added to the plot itself via :meth:`.add_curve` or the
-    :meth:`.creation_requested` ``pyqtSlot`` which takes the current status of
+    :meth:`.creation_requested` ``Slot`` which takes the current status of
     the requested combinations
 
     Parameters
@@ -127,7 +128,7 @@ class TyphonTimePlot(QWidget):
         # Select new random color
         self.ui.color.brush = QBrush(random_color(), Qt.SolidPattern)
 
-    @pyqtSlot()
+    @Slot()
     def remove_curve(self, name):
         """
         Remove a curve from the plot
@@ -149,7 +150,7 @@ class TyphonTimePlot(QWidget):
         else:
             logger.error("Curve %r was not found in DeviceTimePlot", name)
 
-    @pyqtSlot()
+    @Slot()
     def creation_requested(self):
         """
         Reaction to ``create_button`` press

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -12,7 +12,7 @@ import logging
 import numpy as np
 from ophyd.utils.epics_pvs import _type_map
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
-from pydm.PyQt.QtCore import pyqtSlot, Qt
+from qtpy.QtCore import Slot, Qt
 
 ##########
 # Module #
@@ -69,10 +69,10 @@ class SignalConnection(PyDMConnection):
         # Add listener
         self.add_listener(channel)
 
-    @pyqtSlot(int)
-    @pyqtSlot(float)
-    @pyqtSlot(str)
-    @pyqtSlot(np.ndarray)
+    @Slot(int)
+    @Slot(float)
+    @Slot(str)
+    @Slot(np.ndarray)
     def put_value(self, new_val):
         """
         Pass a value from the UI to Signal

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -2,15 +2,15 @@
 # Standard #
 ############
 import logging
+from warnings import warn
 
 ############
 # External #
 ############
 from ophyd.signal import EpicsSignal, EpicsSignalBase, EpicsSignalRO
 from ophyd.sim import SignalRO
-from pydm.PyQt.QtCore import QSize
-from pydm.PyQt.QtGui import QHBoxLayout, QLabel, QWidget, QGridLayout
-from warnings import warn
+from qtpy.QtCore import QSize
+from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel, QWidget)
 
 #############
 #  Package  #

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -11,7 +11,8 @@ import random
 # External #
 ############
 from ophyd.signal import EpicsSignalBase
-from pydm.PyQt.QtGui import QApplication, QColor, QStyleFactory
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QApplication, QStyleFactory
 
 #############
 #  Package  #

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -6,8 +6,9 @@ import logging
 ############
 # External #
 ############
-from pydm.PyQt.QtCore import QSize, Qt, pyqtSlot
-from pydm.PyQt.QtGui import QVBoxLayout, QPushButton, QWidget, QListWidgetItem
+from qtpy.QtCore import QSize, Qt, Slot
+from qtpy.QtWidgets import (QListWidgetItem, QPushButton, QVBoxLayout,
+                            QWidget)
 from pydm.widgets import PyDMLabel, PyDMEnumComboBox, PyDMLineEdit
 
 ###########
@@ -58,7 +59,7 @@ class TogglePanel(QWidget):
         self.layout().addWidget(self.hide_button)
         self.hide_button.clicked.connect(self.show_contents)
 
-    @pyqtSlot(bool)
+    @Slot(bool)
     def show_contents(self, show):
         """
         Show the contents of the Widget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Future releases of `PyDM` will no longer contain the homebrewed `PyQt` interface layer. This eliminates any dependency on those imports and instead used the agreed upon `qtpy` layer.

I also noticed that `numpy` is imported but is not explicitly listed as a dependency. If there is ever a world in which all of the `typhon` depndencies do not also depend on `numpy` we are now prepared.

Finally, in `ophyd=1.3` three new signals were added to `ophyd.sim.SynAxis`. These are effectively plotted by the `DeviceTimePlot` but the test had the number fixed to '2'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #94 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests
