### PR TITLE
ENH: Childless DeviceDisplay

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -98,6 +98,12 @@ def test_display(device):
                    for disp in display.ui.subdisplay.children()]
     assert all([getattr(device, dev) in sub_devices
                 for dev in device._sub_devices])
+    # No children
+    childless = DeviceDisplay(device, children=False)
+    sub_display = [disp
+                   for disp in childless.ui.subdisplay.children()
+                   if isinstance(disp, DeviceDisplay)]
+    assert len(sub_display) == 0
     return display
 
 

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -324,17 +324,22 @@ class DeviceDisplay(TyphonDisplay):
     image : str, optional
         Path to image to add to display
 
+    children: str, optional
+        Choice to include child Device components
+
     parent : QWidget, optional
     """
-    def __init__(self, device, methods=None, image=None, parent=None):
+    def __init__(self, device, methods=None, image=None,
+                 children=True, parent=None):
         super().__init__(clean_name(device, strip_parent=False),
                          image=image, parent=parent)
         # Examine and store device for later reference
         self.device = device
         self.device_description = self.device.describe()
         # Handle child devices
-        for dev_name in self.device._sub_devices:
-            self.add_subdevice(getattr(self.device, dev_name))
+        if children:
+            for dev_name in self.device._sub_devices:
+                self.add_subdevice(getattr(self.device, dev_name))
 
         # Create read and configuration panels
         for attr in self.device.read_attrs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Complicated devices like `AreaDetector` may have a large number of child components. For applications like the `lightpath` we may not need to create displays for all these as connections take time. This PR makes the choice to draw widgets for `children` an option in `__init__`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test for new feature

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added option  to docstring
