### PR TITLE
MAINT: Utility Extensions and Modifications

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from ophyd import Device, Component as Cpt
 
-from typhon.utils import use_stylesheet, clean_name
+from typhon.utils import use_stylesheet, clean_name, grab_hints
 
 
 class NestedDevice(Device):
@@ -19,6 +19,12 @@ def test_clean_name():
                       strip_parent=False) == 'test radial phi'
     assert clean_name(device.radial.phi, strip_parent=True) == 'phi'
     assert clean_name(device.radial.phi, strip_parent=device) == 'radial phi'
+
+
+def test_grab_hints(motor):
+    hint_names = [cpt.name for cpt in grab_hints(motor)]
+    assert all([field in hint_names
+                for field in motor.hints['fields']])
 
 
 def test_stylesheet():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,24 @@
-from typhon.utils import use_stylesheet
+from ophyd import Device, Component as Cpt
+
+from typhon.utils import use_stylesheet, clean_name
+
+
+class NestedDevice(Device):
+    phi = Cpt(Device)
+
+
+class LayeredDevice(Device):
+    radial = Cpt(NestedDevice)
+
+
+def test_clean_name():
+    device = LayeredDevice(name='test')
+    assert clean_name(device.radial, strip_parent=False) == 'test radial'
+    assert clean_name(device.radial, strip_parent=True) == 'radial'
+    assert clean_name(device.radial.phi,
+                      strip_parent=False) == 'test radial phi'
+    assert clean_name(device.radial.phi, strip_parent=True) == 'phi'
+    assert clean_name(device.radial.phi, strip_parent=device) == 'radial phi'
 
 
 def test_stylesheet():

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -343,20 +343,21 @@ class DeviceDisplay(TyphonDisplay):
 
         # Create read and configuration panels
         for attr in self.device.read_attrs:
-            if attr not in self.device._sub_devices:
-                self.read_panel.add_signal(getattr(self.device, attr),
-                                           clean_attr(attr))
+            signal = getattr(self.device, attr)
+            if not isinstance(signal, Device):
+                self.read_panel.add_signal(signal, clean_attr(attr))
         for attr in self.device.configuration_attrs:
-            if attr not in self.device._sub_devices:
-                self.config_panel.add_signal(getattr(self.device, attr),
-                                             clean_attr(attr))
+            signal = getattr(self.device, attr)
+            if not isinstance(signal, Device):
+                self.config_panel.add_signal(signal, clean_attr(attr))
         # Catch the rest of the signals add to misc panel below misc_button
         for attr in self.device.component_names:
             if attr not in (self.device.read_attrs
                             + self.device.configuration_attrs
                             + self.device._sub_devices):
-                self.misc_panel.add_signal(getattr(self.device, attr),
-                                           clean_attr(attr))
+                signal = getattr(self.device, attr)
+                if not isinstance(signal, Device):
+                    self.misc_panel.add_signal(signal, clean_attr(attr))
         # Add our methods to the panel
         methods = methods or list()
         for method in methods:

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -33,7 +33,7 @@ def register_signal(signal):
     """
     # Warn the user if they are adding twice
     if signal.name in signal_registry:
-        logger.error("A signal named %s is already registered!", signal.name)
+        logger.debug("A signal named %s is already registered!", signal.name)
         return
     signal_registry[signal.name] = signal
 

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -8,14 +8,13 @@ from warnings import warn
 # External #
 ############
 from ophyd.signal import EpicsSignal, EpicsSignalBase, EpicsSignalRO
-from ophyd.sim import SignalRO
 from qtpy.QtCore import QSize
 from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel, QWidget)
 
 #############
 #  Package  #
 #############
-from .utils import channel_name
+from .utils import channel_name, is_signal_ro
 from .widgets import TyphonLineEdit, TyphonComboBox, TyphonLabel
 from .plugins import register_signal
 
@@ -134,7 +133,7 @@ class SignalPanel(QWidget):
         # Create the read-only signal
         read = signal_widget(signal, read_only=True)
         # Create the write signal
-        if not isinstance(signal, (SignalRO, EpicsSignalRO)):
+        if not is_signal_ro(signal):
             write = signal_widget(signal)
         else:
             write = None

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -79,7 +79,7 @@ def clean_name(device, strip_parent=True):
         specification for removal at any point of the device schema
     """
     name = device.name
-    if strip_parent:
+    if strip_parent and device.parent:
         if isinstance(strip_parent, ophyd.Device):
             parent_name = strip_parent.name
         else:

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -10,6 +10,7 @@ import random
 ############
 # External #
 ############
+import ophyd
 from ophyd.signal import EpicsSignalBase
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QApplication, QStyleFactory
@@ -54,13 +55,19 @@ def clean_name(device, strip_parent=True):
     ----------
     device: ophyd.Device
 
-    strip_parent: bool
-        Remove the parent name of the device from name
+    strip_parent: bool or Device
+        Remove the parent name of the device from name. If strip_parent is
+        True, the name of the direct parent of the device is stripped. If a
+        device is provided the name of that device is used. This allows
+        specification for removal at any point of the device schema
     """
     name = device.name
-    # Strip the parent name if present and desired
-    if device.parent and strip_parent:
-        name = name.replace(device.parent.name + '_', '')
+    if strip_parent:
+        if isinstance(strip_parent, ophyd.Device):
+            parent_name = strip_parent.name
+        else:
+            parent_name = device.parent.name
+        name = name.replace(parent_name + '_', '')
     # Return the cleaned alias
     return clean_attr(name)
 

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -43,8 +43,7 @@ def clean_attr(attr):
     """
     Create a nicer, human readable alias from a Python attribute name
     """
-    attr = attr.replace('.', '_')
-    return ' '.join([word[0].upper() + word[1:] for word in attr.split('_')])
+    return attr.replace('.', ' ').replace('_', ' ')
 
 
 def clean_name(device, strip_parent=True):

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -42,6 +42,14 @@ def is_signal_ro(signal):
     introspection in the ophyd library. Until that day we need to check classes
     """
     return isinstance(signal, (SignalRO, EpicsSignalRO))
+
+
+def grab_hints(device):
+    """Grab the hints of an ophyd Device"""
+    return [getattr(device, cpt) for cpt in device.read_attrs
+            if getattr(device, cpt).kind == ophyd.Kind.hinted]
+
+
 def channel_name(pv, protocol='ca'):
     """
     Create a valid PyDM channel from a PV name

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -11,7 +11,8 @@ import random
 # External #
 ############
 import ophyd
-from ophyd.signal import EpicsSignalBase
+from ophyd.signal import EpicsSignalBase, EpicsSignalRO
+from ophyd.sim import SignalRO
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QApplication, QStyleFactory
 
@@ -33,6 +34,14 @@ def channel_from_signal(signal):
         return channel_name(signal.name, protocol='sig')
 
 
+def is_signal_ro(signal):
+    """
+    Return whether the signal is read-only
+
+    In the future this may be easier to do through improvements to
+    introspection in the ophyd library. Until that day we need to check classes
+    """
+    return isinstance(signal, (SignalRO, EpicsSignalRO))
 def channel_name(pv, protocol='ca'):
     """
     Create a valid PyDM channel from a PV name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Sometimes you have to use stuff twice to figure out what is useful and what isn't. These utilities are now all being used in the `lightpath` and there were assumptions made in various places that I'd like to unravel. 

#### Changes
* Reduced the `log` level of registering a signal twice. This isn't really a huge deal and checking prior to every signal add is cumbersome.
* We no longer "guess" by capitalizing names in `clean_attr`. It works sometimes but fails for any form of three letter acronym e.t.c
* Add a `is_signal_ro` utility. Someday we may be able to introspect an `ophyd.Signal` but for now we have to check the class. This future proofs us to just change the utility function instead of searching through code
* `grab_hints` is a convenient function to find the hints of a Device. This is a little cumbersome because `hint_attrs` does not exist and `Device.hints` has the "name" properties of all our hinted components which we are not guaranteed to be able to traverse back to. Once again, it is possible `ophyd` will add an easier way to do this and having this logic contained within a utility function will make it easy to swap.
* Finally there was a small issue with deeply nested device structures (`AreaDetector`). We checked that a component was not in `Device._sub_devices` prior to creating a widget for it. However it is possible to have a component be a child of a child which would mean it wouldn't show up in the top level `_sub_devices`. Instead of creating some complicated logic to traverse the tree we just check that the object is not a device.
* `clean_name` can now be passed a device at an arbitrary point in the tree to strip. This again helps with deeply nested device structures. For instance, I may have a component with the name `highlevel_midlevel_myname` and want to strip this down to `midlevel_myname` instead of all the way down to just `myname`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Tests added for new `clean_name` functionality
* The rest of these functions were just repurposed from elsewhere in the library. 