### PR TITLE
FIX: Send signal metadata before value

### DIFF
--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -132,8 +132,6 @@ class SignalConnection(PyDMConnection):
         # Report as connected
         self.write_access_signal.emit(True)
         self.connection_state_signal.emit(True)
-        # Report new value
-        self.send_new_value(signal_val)
         # Report metadata
         for (field, signal) in (
                     ('precision', self.prec_signal),
@@ -144,6 +142,8 @@ class SignalConnection(PyDMConnection):
             # If so emit it to our listeners
             if val:
                 signal.emit(val)
+        # Report new value
+        self.send_new_value(signal_val)
         # If the channel is used for writing to PVs, hook it up to the
         # 'put' methods.
         if channel.value_signal is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Thought I was having an issue with `PyDMEnumComboBox` for days but just realized that the `SignalPlugin` sends the new value before ever sending the `metadata`. We then try to set the value of the `QComboBox` before we have filled it with any information.

This is a good thing to keep in mind for general `Plugin` logic. We can't assume that we are sending this information to `state-less` widget and it would be nice to ensure that all the widgets depend on the same order of information.
