### PR TITLE
MAINT: Tool Restructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs/*
 __pycache__/
 *.py[cod]
 *$py.class
+*.pytest_cache
 
 # Ignore generated MacOS files
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ script:
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD ]]; then
       # Create HTML documentation  
       pushd docs
-      sphinx-autogen -o source/generated source/*.rst
       make html
       popd
       #Publish docs.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,10 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+clean:
+	     -rm -rf $(BUILDDIR)
+		 -rm -rf $(SOURCEDIR)/generated
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = Typhon
 SOURCEDIR     = source

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -93,9 +93,12 @@ user displays.
 
 Using the StyleSheet
 ====================
-While it is no means a requirement, Typhon ships with a custom stylesheet to
+While it is no means a requirement, Typhon ships with two stylesheets to
 improve the look of the widgets. By default this isn't activated, but can be
-configured with `:func:`.use_stylesheet`
+configured with :func:`typhon.use_stylesheet`. The operator can elect whether to use
+the "light" or "dark" stylesheets by using the optional ``dark`` keyword. This
+method also handles setting the "Fusion" ``QStyle`` which helps make the
+interface have an operating system independent look and feel.
 
 Making Modifications
 ====================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = ['sphinx.ext.autodoc',
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+autosummary_generate = True
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ Related Projects
    :hidden:
 
    basic_usage.rst
+   tools.rst
    connections.rst
    python_methods.rst
 

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -1,0 +1,37 @@
+############### 
+Supported Tools
+###############
+
+In experimental environments there are a variety of external tools and 
+applications that are critical to day to day operation. Typhon hopes to
+integrate many of these services into the :class:`.DeviceDisplay` for ease of
+operation. This approach has two advantages; the first is that getting to
+helpful tools requires fewer clicks and therefore less time, secondly, if we
+assume that the context in which they want to use the external tool includes
+this device, we can pre-populate many of the fields for them.
+
+
+Basic Usage
+===========
+All of the tools in ``typhon`` follow a basic pattern. Each one can be
+instantiated as a standalone widget with no ``ophyd`` or ``Device`` required. The
+intention is that these tools could be used in a separate application where the
+underlying information is in a different form. However, in order to make these
+objects easier to interface with ``ophyd`` objects the methods
+:meth:`.TyphonTool.from_device` and :meth:`.TyphonTool.add_device` are
+available. These automatically populate fields according to device structures.
+
+.. autoclass:: typhon.tools.TyphonTool
+   :members:
+
+Tool Classes
+============
+
+.. currentmodule:: typhon.tools
+
+.. autosummary::
+   :toctree: generated
+
+   TyphonLogDisplay 
+   TyphonTimePlot
+

--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -21,14 +21,3 @@ hides and shows the contents. Each variation in Typhon is documented below.
 
    typhon.signal.SignalPanel
    typhon.func.FunctionPanel
-
-Component Widgets
-=================
-
-.. autosummary::
-   :toctree: generated
-
-   typhon.ComponentButton
-   typhon.func.FunctionDisplay
-   typhon.widgets.TogglePanel
-   typhon.widgets.RotatingImage

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,16 @@
+import logging
+
+from ophyd import Device
+
+from typhon.tools import TyphonLogDisplay
+
+
+def test_log_display(qapp):
+    dev = Device(name='test')
+    log_tool = TyphonLogDisplay.from_device(dev)
+    dev.log.error(dev.name)
+    assert dev.name in log_tool.logdisplay.text.toPlainText()
+    dev2 = Device(name='blah')
+    log_tool.add_device(dev2)
+    dev2.log.info(dev2.name)
+    assert dev2.name in log_tool.logdisplay.text.toPlainText()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -18,7 +18,7 @@ from qtpy.QtGui import QColor
 # Module #
 ##########
 from typhon import register_signal
-from typhon.plot import ChannelDisplay, TyphonTimePlot, DeviceTimePlot
+from typhon.tools.plot import ChannelDisplay, TyphonTimePlot, DeviceTimePlot
 
 @pytest.fixture(scope='session')
 def sim_signal():

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -78,7 +78,7 @@ def test_curve_creation_button(sim_signal):
     assert len(ttp.ui.timeplot.curves) == 1
 
 def test_device_plot(motor):
-    dtp = DeviceTimePlot(motor)
+    dtp = TyphonTimePlot.from_device(motor)
     # Add the hint
     assert len(dtp.ui.timeplot.curves) == 1
     # Added all the signals

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -9,7 +9,6 @@ import os.path
 ############
 from ophyd import Device
 from pydm.widgets.drawing import PyDMDrawingImage
-from pydm.widgets.logdisplay import PyDMLogDisplay
 from qtpy import uic
 from qtpy.QtCore import Slot, Qt, QModelIndex
 from qtpy.QtWidgets import QScrollArea, QWidget
@@ -21,8 +20,7 @@ from .func import FunctionPanel
 from .signal import SignalPanel
 from .utils import ui_dir, clean_attr, clean_name
 from .widgets import TyphonSidebarItem
-from .tools import TyphonTimePlot
-
+from .tools import TyphonTimePlot, TyphonLogDisplay
 
 logger = logging.getLogger(__name__)
 
@@ -365,5 +363,4 @@ class DeviceDisplay(TyphonDisplay):
         # Add the plot tool
         self.add_tool('Plotting Tool', TyphonTimePlot.from_device(device))
         # Add a LogWidget to our toolset
-        self.add_tool('Device Log', PyDMLogDisplay(logname=device.log.name,
-                                                   level=logging.INFO))
+        self.add_tool('Device Log', TyphonLogDisplay.from_device(device))

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -21,7 +21,7 @@ from .func import FunctionPanel
 from .signal import SignalPanel
 from .utils import ui_dir, clean_attr, clean_name
 from .widgets import TyphonSidebarItem
-from .plot import DeviceTimePlot
+from .tools import DeviceTimePlot
 
 
 logger = logging.getLogger(__name__)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -21,7 +21,7 @@ from .func import FunctionPanel
 from .signal import SignalPanel
 from .utils import ui_dir, clean_attr, clean_name
 from .widgets import TyphonSidebarItem
-from .tools import DeviceTimePlot
+from .tools import TyphonTimePlot
 
 
 logger = logging.getLogger(__name__)
@@ -363,7 +363,7 @@ class DeviceDisplay(TyphonDisplay):
         for method in methods:
                 self.method_panel.add_method(method)
         # Add the plot tool
-        self.add_tool('Plotting Tool', DeviceTimePlot(device))
+        self.add_tool('Plotting Tool', TyphonTimePlot.from_device(device))
         # Add a LogWidget to our toolset
         self.add_tool('Device Log', PyDMLogDisplay(logname=device.log.name,
                                                    level=logging.INFO))

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -62,7 +62,7 @@ def signal_widget(signal, read_only=False):
             desc = signal.describe()[signal.name]
         except Exception as exc:
             logger.error("Unable to connect to %r during widget creation",
-                         signal)
+                         signal.name)
             desc = {}
         # Create a QCombobox if the widget has enum_strs
         if 'enum_strs' in desc:

--- a/typhon/tools/__init__.py
+++ b/typhon/tools/__init__.py
@@ -1,0 +1,4 @@
+"""Module for all insertable Typhon tools"""
+__all__ = ['DeviceTimePlot']
+
+from .plot import DeviceTimePlot

--- a/typhon/tools/__init__.py
+++ b/typhon/tools/__init__.py
@@ -1,4 +1,4 @@
 """Module for all insertable Typhon tools"""
-__all__ = ['DeviceTimePlot']
+__all__ = ['TyphonTimePlot']
 
-from .plot import DeviceTimePlot
+from .plot import TyphonTimePlot

--- a/typhon/tools/__init__.py
+++ b/typhon/tools/__init__.py
@@ -1,5 +1,6 @@
 """Module for all insertable Typhon tools"""
-__all__ = ['TyphonLogDisplay', 'TyphonTimePlot']
+__all__ = ['TyphonLogDisplay', 'TyphonTimePlot', 'TyphonTool']
 
+from .core import TyphonTool
 from .plot import TyphonTimePlot
 from .log import TyphonLogDisplay

--- a/typhon/tools/__init__.py
+++ b/typhon/tools/__init__.py
@@ -2,3 +2,4 @@
 __all__ = ['TyphonTimePlot']
 
 from .plot import TyphonTimePlot
+from .log import TyphonLogDisplay

--- a/typhon/tools/__init__.py
+++ b/typhon/tools/__init__.py
@@ -1,5 +1,5 @@
 """Module for all insertable Typhon tools"""
-__all__ = ['TyphonTimePlot']
+__all__ = ['TyphonLogDisplay', 'TyphonTimePlot']
 
 from .plot import TyphonTimePlot
 from .log import TyphonLogDisplay

--- a/typhon/tools/core.py
+++ b/typhon/tools/core.py
@@ -1,0 +1,24 @@
+import logging
+
+from qtpy.QtWidgets import QWidget
+
+logger = logging.getLogger(__name__)
+
+
+class TyphonTool(QWidget):
+    """Mixin for all Typhon tool creation"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.devices = list()
+
+    def add_device(self, device):
+        """Add a new device to the tool"""
+        logger.debug("Adding device %s ...", device.name)
+        self.devices.append(device)
+
+    @classmethod
+    def from_device(cls, device, parent=None):
+        """Create a new instance of the tool for a Device"""
+        instance = cls(parent=parent)
+        instance.add_device(device)
+        return instance

--- a/typhon/tools/core.py
+++ b/typhon/tools/core.py
@@ -6,19 +6,40 @@ logger = logging.getLogger(__name__)
 
 
 class TyphonTool(QWidget):
-    """Mixin for all Typhon tool creation"""
+    """Base widget for all Typhon Tool creation"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.devices = list()
 
     def add_device(self, device):
-        """Add a new device to the tool"""
+        """
+        Add a new device to the tool
+
+        Parameters
+        ----------
+        device : ophyd.Device
+        """
         logger.debug("Adding device %s ...", device.name)
         self.devices.append(device)
 
     @classmethod
     def from_device(cls, device, parent=None, **kwargs):
-        """Create a new instance of the tool for a Device"""
+        """
+        Create a new instance of the tool for a Device
+
+        Shortcut for:
+
+        .. code::
+
+            tool = TyphonTool()
+            tool.add_device(device)
+
+        Parameters
+        ----------
+        device: ophyd.Device
+
+        parent: QWidget
+        """
         instance = cls(parent=parent, **kwargs)
         instance.add_device(device)
         return instance

--- a/typhon/tools/core.py
+++ b/typhon/tools/core.py
@@ -17,8 +17,8 @@ class TyphonTool(QWidget):
         self.devices.append(device)
 
     @classmethod
-    def from_device(cls, device, parent=None):
+    def from_device(cls, device, parent=None, **kwargs):
         """Create a new instance of the tool for a Device"""
-        instance = cls(parent=parent)
+        instance = cls(parent=parent, **kwargs)
         instance.add_device(device)
         return instance

--- a/typhon/tools/log.py
+++ b/typhon/tools/log.py
@@ -1,0 +1,27 @@
+import logging
+
+from pydm.widgets.logdisplay import PyDMLogDisplay
+from qtpy.QtWidgets import QVBoxLayout
+
+from .core import TyphonTool
+
+
+class TyphonLogDisplay(TyphonTool):
+    """Typhon Logging Display"""
+    def __init__(self, level=logging.INFO, parent=None):
+        super().__init__(parent=parent)
+        self.logdisplay = PyDMLogDisplay(level=level)
+        self.setLayout(QVBoxLayout())
+        self.layout().addWidget(self.logdisplay)
+
+    def add_device(self, device):
+        """Add a device to the logging display"""
+        super().add_device(device)
+        # If this is the first device
+        if len(self.devices) == 1:
+            self.logdisplay.logName = device.log.name
+        # If we have already attached a device, just set it to NOTSET to let
+        # the existing handler do all the filtering
+        else:
+            device.log.setLevel(logging.NOTSET)
+            device.log.addHandler(self.logdisplay.handler)

--- a/typhon/tools/plot.py
+++ b/typhon/tools/plot.py
@@ -20,8 +20,8 @@ from qtpy.QtWidgets import QApplication, QWidget
 ##########
 # Module #
 ##########
-from .utils import (ui_dir, channel_from_signal, clean_attr, random_color,
-                    clean_name)
+from ..utils import (ui_dir, channel_from_signal, clean_attr, random_color,
+                     clean_name)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Created a base API for all `typhon` tools to follow. This makes official the new structure in which every tool can be instantiated by itself, but if you want to automatically make it useful with an object you can use a `from_device` class method instead.

Also made a new widget `TyphonLogDisplay` to contain the `PyDMLogDisplay` widget. This was necessary to support multiple devices logging to the same widget. It also leaves room to expand the feature set of the widget to save the log, post to elog e.t.c
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #106 
Part way to addressing #107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test for `TyphonLogDisplay`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Documentation has been ignored for too long. Addressing this in the following PR

