### PR TITLE
ENH: QtConsole

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,3 +87,7 @@ after_success:
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
       anaconda upload bld-dir/linux-64/*.tar.bz2
     fi
+
+after_failure:
+  - cat logs/run_tests_log.txt
+  - cat logs/run_tests_log.txt.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,14 @@ before_script:
   - sleep 1
 
 script:
-  - coverage run run_tests.py --timeout 15 
+  - coverage run run_tests.py --disable-warnings 
   - coverage report -m
+    #- coverage report -m
   - flake8 typhon
   # Test again but with installed version
   - mkdir notest
   - mv typhon/*.* notest
-  - python run_tests.py
+  - python run_tests.py --disable-warnings
   - mv notest/* typhon
   - rmdir notest
   # Build docs

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
       - ophyd >=1.2.0
       - pydm >=1.2.0
       - qdarkstyle
+      - qtconsole
       - qtpy
 
 test:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 codecov
 doctr
 flake8
+happi
 ipython
 matplotlib
 pytest

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -26,6 +26,7 @@ Tool Classes
 .. autosummary::
    :toctree: generated
 
+   TyphonConsole
    TyphonLogDisplay 
    TyphonTimePlot
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ git+https://github.com/slaclab/pydm.git
 git+https://github.com/NSLS-II/ophyd.git
 git+https://github.com/pcdshub/QDarkStyleSheet.git
 numpy
+qtconsole
 qtpy

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -17,7 +17,7 @@ def test_base_console():
 
 
 @show_widget
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(30)
 def test_add_device(qapp):
     # Create a device and attach metadata
     md = happi.Device(name='Test This', prefix='Tst:This:1', beamline='TST',
@@ -28,9 +28,8 @@ def test_add_device(qapp):
     tc = TyphonConsole.from_device(device)
     # Check that we created the object in the shell
     tc.kernel_client.execute('print(test_this.here)', silent=False)
-    while 'In [' not in tc._control.toPlainText():
+    while md.kwargs['here'] not in tc._control.toPlainText():
         qapp.processEvents()
-    assert md.kwargs['here'] in tc._control.toPlainText()
     # Smoke test not happi Device
     tc.add_device(types.SimpleNamespace(hi=3))
     return tc

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -13,6 +13,7 @@ def test_base_console():
     assert tc.kernel_manager.is_alive()
     tc.shutdown()
     assert not tc.kernel_manager.is_alive()
+    tc.shutdown()
 
 
 @show_widget

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -11,6 +11,8 @@ from .conftest import show_widget
 def test_base_console():
     tc = TyphonConsole()
     assert tc.kernel_manager.is_alive()
+    tc.shutdown()
+    assert not tc.kernel_manager.is_alive()
 
 
 @show_widget

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,30 @@
+import types
+import happi
+from happi.loader import from_container
+from typhon.tools import TyphonConsole
+
+from .conftest import show_widget
+
+
+def test_base_console():
+    tc = TyphonConsole()
+    assert tc.kernel_manager.is_alive()
+
+
+@show_widget
+def test_add_device(qapp):
+    # Create a device and attach metadata
+    md = happi.Device(name='Test This', prefix='Tst:This:1', beamline='TST',
+                      device_class='types.SimpleNamespace', args=list(),
+                      kwargs={'here': 'very unique text'})
+    device = from_container(md)
+    # Add the device to the Console
+    tc = TyphonConsole.from_device(device)
+    # Check that we created the object in the shell
+    tc.kernel_client.execute('print(test_this.here)', silent=False)
+    while 'In [' not in tc._control.toPlainText():
+        qapp.processEvents()
+    assert md.kwargs['here'] in tc._control.toPlainText()
+    # Smoke test not happi Device
+    tc.add_device(types.SimpleNamespace(hi=3))
+    return tc

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,6 +1,8 @@
 import types
+
 import happi
 from happi.loader import from_container
+import pytest
 from typhon.tools import TyphonConsole
 
 from .conftest import show_widget
@@ -12,6 +14,7 @@ def test_base_console():
 
 
 @show_widget
+@pytest.mark.timeout(60)
 def test_add_device(qapp):
     # Create a device and attach metadata
     md = happi.Device(name='Test This', prefix='Tst:This:1', beamline='TST',

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -25,12 +25,14 @@ def test_device_display(device):
 
 
 @show_widget
-def test_display_with_images(test_images):
+def test_display_with_images(device, test_images):
     (lenna, python) = test_images
     # Create a display with our image
     panel = TyphonDisplay(name="Image Test", image=lenna)
     assert panel.image_widget.filename == lenna
     # Add our python image
     panel.add_image(python)
+    assert panel.image_widget.filename == python
+    panel = TyphonDisplay.from_device(device, image=python)
     assert panel.image_widget.filename == python
     return panel

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -27,7 +27,7 @@ def test_suite(device):
                       for i in range(suite.component_list.count())]
     assert len(child_displays) == len(device._sub_devices)
     # Default tools are loaded
-    assert len(suite.tools) == 2
+    assert len(suite.tools) == 3
     assert len(suite.tools[0].devices) == 1
     # No children
     childless = TyphonSuite.from_device(device, children=False)

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -17,7 +17,7 @@ from qtpy.QtCore import Slot, Qt, QModelIndex
 from .display import TyphonDisplay
 from .utils import ui_dir, clean_name, TyphonBase
 from .widgets import TyphonSidebarItem
-from .tools import TyphonTimePlot, TyphonLogDisplay
+from .tools import TyphonTimePlot, TyphonLogDisplay, TyphonConsole
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +233,8 @@ class TyphonSuite(TyphonBase):
     @classmethod
     def from_device(cls, device, parent=None,
                     tools={'Log': TyphonLogDisplay,
-                           'StripTool': TyphonTimePlot},
+                           'StripTool': TyphonTimePlot,
+                           'Console': TyphonConsole},
                     **kwargs):
         """
         Create a new TyphonDisplay from an ophyd.Device

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -217,7 +217,8 @@ class TyphonSuite(TyphonBase):
         super().add_device(device)
         # Add the device to the main panel
         self.device_panel.add_device(device, methods=methods)
-        self.device_panel.add_image(image)
+        if image:
+            self.device_panel.add_image(image)
         # Add a device to all the tool displays
         for tool in self.tools:
             try:

--- a/typhon/tools/__init__.py
+++ b/typhon/tools/__init__.py
@@ -1,5 +1,6 @@
 """Module for all insertable Typhon tools"""
-__all__ = ['TyphonLogDisplay', 'TyphonTimePlot']
+__all__ = ['TyphonConsole', 'TyphonLogDisplay', 'TyphonTimePlot']
 
+from .console import TyphonConsole
 from .plot import TyphonTimePlot
 from .log import TyphonLogDisplay

--- a/typhon/tools/console.py
+++ b/typhon/tools/console.py
@@ -100,7 +100,7 @@ try:
 
 except ImportError:
     logger.info("Unable to import ``happi``. Devices will not be added "
-                "to the ``TyphonConsole`` unless ``TyphoConsole.add_device`` "
+                "to the ``TyphonConsole`` unless ``TyphonConsole.add_device`` "
                 "is implemented.")
 
     # Dummy pass-through function

--- a/typhon/tools/console.py
+++ b/typhon/tools/console.py
@@ -52,9 +52,12 @@ class TyphonConsole(RichJupyterWidget, TyphonBase):
 
     def shutdown(self):
         """Shutdown the Jupyter Kernel"""
-        logger.debug("Stopping Jupyter Client")
-        self.kernel_client.stop_channels()
-        self.kernel_manager.shutdown_kernel()
+        if self.kernel_manager.is_alive():
+            logger.debug("Stopping Jupyter Client")
+            self.kernel_client.stop_channels()
+            self.kernel_manager.shutdown_kernel()
+        else:
+            logger.debug("Kernel is already shutdown.")
 
 
 try:

--- a/typhon/tools/console.py
+++ b/typhon/tools/console.py
@@ -1,0 +1,40 @@
+import logging
+
+from qtconsole.rich_jupyter_widget import RichJupyterWidget
+from qtconsole.manager import QtKernelManager
+
+from ..utils import TyphonBase
+
+logger = logging.getLogger(__name__)
+
+
+class TyphonConsole(RichJupyterWidget, TyphonBase):
+    """IPython widget for Typhon Display"""
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        # Create a Kernel
+        logger.debug("Starting Jupyter Kernel ...")
+        kernel_manager = QtKernelManager(kernel_name='python3')
+        kernel_manager.start_kernel()
+        kernel_client = kernel_manager.client()
+        kernel_client.start_channels()
+        self.kernel_manager = kernel_manager
+        self.kernel_client = kernel_client
+        # Ensure we shutdown the kernel
+        self.exit_requested.connect(self.shutdown)
+        # Styling
+        self.syntax_style = 'monokai'
+        self.set_default_style(colors='Linux')
+
+    def add_device(self, device):
+        pass
+
+    def sizeHint(self):
+        default = super().sizeHint()
+        default.setWidth(600)
+        return default
+
+    def shutdown(self):
+        logger.debug("Stopping Jupyter Client")
+        self.kernel_client.stop_channels()
+        self.kernel_manager.shutdown_kernel()

--- a/typhon/tools/console.py
+++ b/typhon/tools/console.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from time import localtime
 
+from qtpy.QtWidgets import QApplication
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from qtconsole.manager import QtKernelManager
 
@@ -38,7 +39,8 @@ class TyphonConsole(RichJupyterWidget, TyphonBase):
         self.kernel_manager = kernel_manager
         self.kernel_client = kernel_client
         # Ensure we shutdown the kernel
-        self.exit_requested.connect(self.shutdown)
+        app = QApplication.instance()
+        app.aboutToQuit.connect(self.shutdown)
         # Styling
         self.syntax_style = 'monokai'
         self.set_default_style(colors='Linux')

--- a/typhon/tools/console.py
+++ b/typhon/tools/console.py
@@ -1,9 +1,13 @@
+import hashlib
 import logging
+import os
+import tempfile
+from time import localtime
 
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from qtconsole.manager import QtKernelManager
 
-from ..utils import TyphonBase
+from ..utils import TyphonBase, make_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +30,6 @@ class TyphonConsole(RichJupyterWidget, TyphonBase):
         self.syntax_style = 'monokai'
         self.set_default_style(colors='Linux')
 
-    def add_device(self, device):
-        pass
-
     def sizeHint(self):
         default = super().sizeHint()
         default.setWidth(600)
@@ -38,3 +39,53 @@ class TyphonConsole(RichJupyterWidget, TyphonBase):
         logger.debug("Stopping Jupyter Client")
         self.kernel_client.stop_channels()
         self.kernel_manager.shutdown_kernel()
+
+
+try:
+    import happi
+
+    def add_device(obj, device):
+        # Needs metadata
+        if not hasattr(device, 'md'):
+            logger.error("Device %r has no stored metadata. "
+                         "Unable to load in TyphonConsole",
+                         device)
+            return
+        # Create a temporary file
+        name = hashlib.md5(str(localtime()).encode('utf-8')).hexdigest()
+        name = os.path.join(tempfile.gettempdir(), name)
+        try:
+            # Dump the device in the tempfile
+            client = happi.Client(path=name, initialize=True)
+            client.add_device(device.md)
+            # Create a valid Python identifier
+            python_name = make_identifier(device.md.name)
+            # Create the script to load the device
+            load_script = (
+                       f'import happi; '
+                       f'from happi.loader import from_container; '
+                       f'client = happi.Client(path="{name}"); '
+                       f'md = client.find_device(name="{device.md.name}"); '
+                       f'{python_name} = from_container(md)')
+            # Execute the script
+            obj.kernel_client.execute(load_script, silent=True)
+        except Exception as exc:
+            logger.exception("Unable to add device %r to TyphonConsole.",
+                             device.md.name)
+            # Cleanup after ourselves
+            if os.path.exists(name):
+                os.remove(name)
+
+    # Set the TyphonConsole up to load devices
+    TyphonConsole.add_device = add_device
+
+except ImportError:
+    logger.info("Unable to import ``happi``. Devices will not be added "
+                "to the ``TyphonConsole`` unless ``TyphoConsole.add_device`` "
+                "is implemented.")
+
+    # Dummy pass-through function
+    def add_device(obj, x):
+        pass
+
+    TyphonConsole.add_device = add_device

--- a/typhon/tools/console.py
+++ b/typhon/tools/console.py
@@ -13,7 +13,20 @@ logger = logging.getLogger(__name__)
 
 
 class TyphonConsole(RichJupyterWidget, TyphonBase):
-    """IPython widget for Typhon Display"""
+    """
+    IPython Widget for Typhon Display
+
+    This widget handles starting a ``JupyterKernel`` and connecting an IPython
+    console in which the user can type Python commands. It is important to note
+    that the kernel in which commands are executed is a completely separate
+    process. This protects the user against locking themselves out of the GUI,
+    but makes it difficult to pass the Device.
+
+    To get around this caveat, this widget uses ``happi`` to pass the Device
+    between the processes. This is not a strict requirement, but if ``happi``
+    is not installed, users will need to create a custom ``add_device`` method
+    if they want their devices loaded in both the GUI and console.
+    """
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         # Create a Kernel
@@ -36,6 +49,7 @@ class TyphonConsole(RichJupyterWidget, TyphonBase):
         return default
 
     def shutdown(self):
+        """Shutdown the Jupyter Kernel"""
         logger.debug("Stopping Jupyter Client")
         self.kernel_client.stop_channels()
         self.kernel_manager.shutdown_kernel()

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -4,6 +4,7 @@ Utility functions for typhon
 ############
 # Standard #
 ############
+import re
 import logging
 import os.path
 import random
@@ -168,3 +169,21 @@ class TyphonBase(QWidget):
         instance = cls(parent=parent, **kwargs)
         instance.add_device(device)
         return instance
+
+
+def make_identifier(name):
+    """Make a Python string into a valid Python identifier"""
+    # That was easy
+    if name.isidentifier():
+        return name
+    # Lowercase
+    name = name.lower()
+    # Leading / following whitespace
+    name = name.strip()
+    # Intermediate whitespace should be underscores
+    name = re.sub('[\\s\\t\\n]+', '_', name)
+    # Remove invalid characters
+    name = re.sub('[^0-9a-zA-Z_]', '', name)
+    # Remove leading characters until we find a letter or an underscore
+    name = re.sub('^[^a-zA-Z_]+', '', name)
+    return name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added `QtConsole` as `TyphonConsole` tool. This allows operators to access Python functions that may not be accessible through the GUI. The most difficult part was passing through a `Device` to the completely separate process. I got around this by dumping the Device into `json` using `happi` and the picking it up on the other side. 

**Note**: I tried to do this with `tempfile` and couldn't get it work which is why I make a random filename myself

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #74 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests creation and `happi` device loading

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to `tools` autosummary

## Screenshots (if appropriate):
<img width="1036" alt="screen shot 2018-10-09 at 1 39 42 pm" src="https://user-images.githubusercontent.com/25753048/46697148-da3b0980-cbc8-11e8-9681-e151911dd8ef.png">
