### PR TITLE
Grab Kind Utility

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
-from ophyd import Device, Component as Cpt
 from qtpy.QtWidgets import QWidget
+from ophyd import Device, Component as Cpt, Kind
 
-from typhon.utils import use_stylesheet, clean_name, grab_hints
+from typhon.utils import use_stylesheet, clean_name, grab_hints, grab_kind
 
 
 class NestedDevice(Device):
@@ -33,3 +33,13 @@ def test_stylesheet(qtbot):
     qtbot.addWidget(widget)
     use_stylesheet(widget=widget)
     use_stylesheet(widget=widget, dark=True)
+
+
+def test_grab_kind(motor):
+    assert len(grab_kind(motor, 'hinted')) == len(motor.hints['fields'])
+    assert len(grab_kind(motor, 'normal')) == len(motor.read_attrs)
+    assert len(grab_kind(motor, Kind.config)) == len(motor.configuration_attrs)
+    omitted = (len(motor.component_names)
+               - len(motor.read_attrs)
+               - len(motor.configuration_attrs))
+    assert len(grab_kind(motor, 'omitted')) == omitted

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -9,7 +9,7 @@ from qtpy.QtCore import Qt
 
 from .func import FunctionPanel
 from .signal import SignalPanel
-from .utils import ui_dir, clean_attr, clean_name, TyphonBase
+from .utils import ui_dir, clean_attr, clean_name, TyphonBase, grab_kind
 
 logger = logging.getLogger(__name__)
 
@@ -119,21 +119,12 @@ class TyphonDisplay(TyphonBase):
         """
         super().add_device(device)
         # Create read and configuration panels
-        for attr in device.read_attrs:
-            signal = getattr(device, attr)
-            if not isinstance(signal, Device):
-                self.read_panel.add_signal(signal, clean_attr(attr))
-        for attr in device.configuration_attrs:
-            signal = getattr(device, attr)
-            if not isinstance(signal, Device):
-                self.config_panel.add_signal(signal, clean_attr(attr))
-        # Catch the rest of the signals add to misc panel below misc_button
-        for attr in device.component_names:
-            if attr not in (device.read_attrs
-                            + device.configuration_attrs):
-                signal = getattr(device, attr)
-                if not isinstance(signal, Device):
-                    self.misc_panel.add_signal(signal, clean_attr(attr))
+        for attr, signal in grab_kind(device, 'normal'):
+            self.read_panel.add_signal(signal, clean_attr(attr))
+        for attr, signal in grab_kind(device, 'config'):
+            self.config_panel.add_signal(signal, clean_attr(attr))
+        for attr, signal in grab_kind(device, 'omitted'):
+            self.misc_panel.add_signal(signal, clean_attr(attr))
         # Add our methods to the panel
         methods = methods or list()
         for method in methods:

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -5,14 +5,16 @@ Utility functions for typhon
 # Standard #
 ############
 import re
+from functools import partial
 import logging
 import os.path
 import random
+import warnings
 
 ############
 # External #
 ############
-import ophyd
+from ophyd import Kind, Device
 from ophyd.signal import EpicsSignalBase, EpicsSignalRO
 from ophyd.sim import SignalRO
 from qtpy.QtGui import QColor
@@ -47,10 +49,31 @@ def is_signal_ro(signal):
     return isinstance(signal, (SignalRO, EpicsSignalRO))
 
 
+def grab_kind(device, kind):
+    """Grab all signals of a specific Kind from a Device"""
+    # Accept actual Kind or string value
+    if not isinstance(kind, Kind):
+        kind = Kind[kind]
+    # Find the right attribute store
+    kind_attr = {Kind.hinted: device.read_attrs,
+                 Kind.normal: device.read_attrs,
+                 Kind.config: device.configuration_attrs,
+                 Kind.omitted: [attr for attr in device.component_names
+                                if attr not in device.read_attrs +
+                                device.configuration_attrs]}[kind]
+    # Return that kind filtered for devices
+    signals = []
+    for attr in kind_attr:
+        cpt = getattr(device, attr)
+        if cpt.kind >= kind and not isinstance(cpt, Device):
+            signals.append((attr, cpt))
+    return signals
+
+
 def grab_hints(device):
-    """Grab the hints of an ophyd Device"""
-    return [getattr(device, cpt) for cpt in device.read_attrs
-            if getattr(device, cpt).kind == ophyd.Kind.hinted]
+    """Grab all the hinted signals from a Device"""
+    warnings.warn("This will be deprecated. Use ``grab_kind``.")
+    return [cpt[1] for cpt in grab_kind(device, kind=Kind.hinted)]
 
 
 def channel_name(pv, protocol='ca'):
@@ -83,7 +106,7 @@ def clean_name(device, strip_parent=True):
     """
     name = device.name
     if strip_parent and device.parent:
-        if isinstance(strip_parent, ophyd.Device):
+        if isinstance(strip_parent, Device):
             parent_name = strip_parent.name
         else:
             parent_name = device.parent.name

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -5,7 +5,6 @@ Utility functions for typhon
 # Standard #
 ############
 import re
-from functools import partial
 import logging
 import os.path
 import random


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There are a number of places in the library where we grab a certain `Kind` off of a device. This now unified in a single function. When `typhon` first started there was no `kind` option so this wasn't quite possible.