### PR TITLE
Happi Plugin

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
 
     run:
       - python
+      - happi
       - numpy
       - ophyd >=1.2.0
       - pydm >=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/pcdshub/happi.git
 git+https://github.com/slaclab/pydm.git
 git+https://github.com/NSLS-II/ophyd.git
 git+https://github.com/pcdshub/QDarkStyleSheet.git

--- a/tests/plugins/happi.json
+++ b/tests/plugins/happi.json
@@ -1,0 +1,23 @@
+{
+    "Tst:This": {
+        "_id": "Tst:This",
+        "active": true,
+        "args": [],
+        "beamline": "TST",
+        "creation": "Mon Oct 22 09:08:55 2018",
+        "device_class": "types.SimpleNamespace",
+        "kwargs": {
+            "name": "{{name}}"
+        },
+        "last_edit": "Mon Oct 22 09:10:11 2018",
+        "macros": null,
+        "name": "test_device",
+        "parent": null,
+        "prefix": "Tst:This",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "Device",
+        "z": -1.0
+    }
+}

--- a/tests/plugins/test_core.py
+++ b/tests/plugins/test_core.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import QWidget
 ###########
 # Package #
 ###########
-from .conftest import DeadSignal, RichSignal
+from ..conftest import DeadSignal, RichSignal
 from typhon.plugins.core import (SignalPlugin, SignalConnection,
                                  register_signal)
 

--- a/tests/plugins/test_happi.py
+++ b/tests/plugins/test_happi.py
@@ -1,0 +1,40 @@
+import os.path
+import types
+from unittest.mock import Mock
+
+from happi import Client, Device
+import pytest
+
+from typhon.plugins.happi import HappiPlugin, HappiChannel, register_client
+
+
+@pytest.fixture(scope='module')
+def client():
+    client = Client(path=os.path.join(os.path.dirname(__file__),
+                                      'happi.json'))
+    register_client(client)
+    return client
+
+
+def test_connection(client):
+    hp = HappiPlugin()
+    # Register a channel and check we received object and metadata
+    mock = Mock()
+    hc = HappiChannel(address='happi://test_device', tx_slot=mock)
+    hp.add_connection(hc)
+    assert mock.called
+    tx = mock.call_args[0][0]
+    assert isinstance(tx['obj'], types.SimpleNamespace)
+    assert isinstance(tx['md'], Device)
+    # Add another object and check that the connection does refire
+    mock2 = Mock()
+    hc2 = HappiChannel(address='happi://test_device', tx_slot=mock2)
+    hp.add_connection(hc2)
+    assert mock2.called
+    mock.assert_called_once()
+
+
+def test_bad_address_smoke(client):
+    hp = HappiPlugin()
+    hc = HappiChannel(address='happi://not_a_device', tx_slot=lambda x: None)
+    hp.add_connection(hc)

--- a/tests/plugins/test_happi.py
+++ b/tests/plugins/test_happi.py
@@ -32,7 +32,10 @@ def test_connection(client):
     hp.add_connection(hc2)
     assert mock2.called
     mock.assert_called_once()
-
+    # Disconnect
+    hp.remove_connection(hc)
+    hp.remove_connection(hc2)
+    assert hp.connections == {}
 
 def test_bad_address_smoke(client):
     hp = HappiPlugin()

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -1,6 +1,7 @@
 import logging
 
-from happi import Client, from_container
+from happi import Client
+from happi.loader import from_container
 from happi.errors import SearchError
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from pydm.widgets.channel import PyDMChannel

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -1,0 +1,88 @@
+import logging
+
+from happi import Client, from_container
+from happi.errors import SearchError
+from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
+from pydm.widgets.channel import PyDMChannel
+from qtpy.QtCore import Signal, Slot
+
+_client = None
+logger = logging.getLogger(__name__)
+
+
+def register_client(client):
+    """Register a Happi Client to be used with the DataPlugin"""
+    global _client
+    _client = client
+
+
+class HappiChannel(PyDMChannel):
+    """
+    PyDMChannel to transport Device Information
+
+    Parameters
+    ----------
+    tx_slot: callable
+        Slot on widget to accept a dictionary of both the device and metadata
+        information
+    """
+    def __init__(self, *, tx_slot, **kwargs):
+        super().__init__(**kwargs)
+        self._tx_slot = tx_slot
+        self._last_md = None
+
+    @Slot(dict)
+    def tx_slot(self, value):
+        """Transmission Slot"""
+        # Do not fire twice for the same device
+        if not self._last_md or self._last_md != value['md']:
+            self._last_md = value['md']
+            self._tx_slot(value)
+        else:
+            logger.debug("HappiChannel %r received same device. "
+                         "Ignoring for now ...", self)
+
+
+class HappiConnection(PyDMConnection):
+    """A PyDMConnection to the Happi Database"""
+    tx = Signal(dict)
+
+    def __init__(self, channel, address, protocol=None, parent=None):
+        super().__init__(channel, address, protocol=protocol, parent=parent)
+        self.add_listener(channel)
+
+    def add_listener(self, channel):
+        """Add a new channel to the existing connection"""
+        super().add_listener(channel)
+        # Connect our channel to the signal
+        self.tx.connect(channel.tx_slot)
+        # Load the device from the Client
+        md = _client.find_device(name=self.address)
+        obj = from_container(md)
+        # Send the device and metdata to all of our subscribers
+        self.tx.emit({'obj': obj, 'md': md})
+
+    def remove_listener(self, channel):
+        """Remove a channel from the database connection"""
+        super().remove_listener(channel)
+        self.tx_slot.disconnect(channel.tx_slot)
+
+
+class HappiPlugin(PyDMPlugin):
+    protocol = 'happi'
+    connection_class = HappiConnection
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # If we haven't made a Client by the time we register the Plugin. Try
+        # and load one from configuration file
+        if not _client:
+            register_client(Client.from_config())
+
+    def add_connection(self, channel):
+        try:
+            super().add_connection(channel)
+        except SearchError:
+            logger.exception("Unable to find device in happi database.")
+        except Exception as exc:
+            logger.exception("Unable to load %r from happi", channel.address)

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -5,7 +5,7 @@ from happi.loader import from_container
 from happi.errors import SearchError
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from pydm.widgets.channel import PyDMChannel
-from qtpy.QtCore import Signal, Slot
+from qtpy.QtCore import Signal, Slot, QObject
 
 _client = None
 logger = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ def register_client(client):
     _client = client
 
 
-class HappiChannel(PyDMChannel):
+class HappiChannel(PyDMChannel, QObject):
     """
     PyDMChannel to transport Device Information
 
@@ -29,6 +29,7 @@ class HappiChannel(PyDMChannel):
     """
     def __init__(self, *, tx_slot, **kwargs):
         super().__init__(**kwargs)
+        QObject.__init__(self)
         self._tx_slot = tx_slot
         self._last_md = None
 

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -67,7 +67,7 @@ class HappiConnection(PyDMConnection):
     def remove_listener(self, channel):
         """Remove a channel from the database connection"""
         super().remove_listener(channel)
-        self.tx_slot.disconnect(channel.tx_slot)
+        self.tx.disconnect(channel.tx_slot)
 
 
 class HappiPlugin(PyDMPlugin):

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -85,6 +85,7 @@ class HappiPlugin(PyDMPlugin):
         try:
             super().add_connection(channel)
         except SearchError:
-            logger.exception("Unable to find device in happi database.")
+            logger.error("Unable to find device for %r in happi database.",
+                         channel)
         except Exception as exc:
             logger.exception("Unable to load %r from happi", channel.address)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A `PyDMPlugin` that can transmit objects and their metadata. This uses the proposed model that will be used in `PyDM` for structured data in the future. There is one signal that sends a dictionary of information to subscribers and it is up to them to parse it. In this case it includes the instantiated object (usually an `ophyd.Device`) and the `happi.Device` that it came from.

Thoughts
-------
This does the job of getting devices to widgets but is kind of awkward in some ways. For instance, if another widget requests the same device, we don't want to send out that information again (might be more expensive to redraw entire devices). In fact we really only want to send the device once, I hope I'm not slamming a round peg in a square hole here


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #38 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for adding `HappiConnection`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- []
