### PR TITLE
Timechart

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
       - qtawesome
       - qtconsole
       - qtpy
+      - timechart
 
 test:
     imports:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -18,7 +18,7 @@ from qtpy.QtGui import QColor
 # Module #
 ##########
 from typhon import register_signal
-from typhon.tools.plot import ChannelDisplay, TyphonTimePlot, DeviceTimePlot
+from typhon.tools.plot import TyphonTimePlot, DeviceTimePlot
 
 @pytest.fixture(scope='session')
 def sim_signal():
@@ -26,14 +26,6 @@ def sim_signal():
     sim_sig.put(3.14)
     register_signal(sim_sig)
     return sim_sig
-
-
-def test_channeldisplay(qtbot):
-    disp = ChannelDisplay('Test Channel', QColor(Qt.white))
-    qtbot.addWidget(disp)
-    assert disp.ui.name.text() == 'Test Channel'
-    assert disp.ui.color.brush.color() == QColor(Qt.white)
-
 
 def test_add_signal(qtbot,sim_signal):
     # Create Signals
@@ -43,34 +35,27 @@ def test_add_signal(qtbot,sim_signal):
     qtbot.addWidget(ttp)
     # Add to list of available signals
     ttp.add_available_signal(epics_sig, 'Epics Signal')
-    assert ttp.ui.signal_combo.itemText(0) == 'Epics Signal'
-    assert ttp.ui.signal_combo.itemData(0) == 'ca://Tst:This'
+    assert ttp.signal_combo.itemText(0) == 'Epics Signal'
+    assert ttp.signal_combo.itemData(0) == 'ca://Tst:This'
     ttp.add_available_signal(sim_signal, 'Simulated Signal')
-    assert ttp.ui.signal_combo.itemText(1) == 'Simulated Signal'
-    assert ttp.ui.signal_combo.itemData(1) == 'sig://tst_this_2'
+    assert ttp.signal_combo.itemText(1) == 'Simulated Signal'
+    assert ttp.signal_combo.itemData(1) == 'sig://tst_this_2'
 
 
 def test_curve_methods(qtbot, sim_signal):
     ttp = TyphonTimePlot()
     qtbot.addWidget(ttp)
-    orig_color = ttp.ui.color.brush
     ttp.add_curve('sig://' + sim_signal.name, name=sim_signal.name)
     # Check that our signal is stored in the mapping
     assert sim_signal.name in ttp.channel_map
-    # Check that our next color is different
-    assert ttp.ui.color.brush != orig_color
-    # Check that our ChannelDisplay is live
-    assert ttp.ui.live_channels.layout().count() == 2  # 1 is a spacer
     # Check that our curve is live
-    assert len(ttp.ui.timeplot.curves) == 1
+    assert len(ttp.timechart.chart.curves) == 1
     # Try and add again
     ttp.add_curve('sig://' + sim_signal.name, name=sim_signal.name)
     # Check we didn't duplicate
-    assert ttp.ui.live_channels.layout().count() == 2  # 1 is a spacer
-    assert len(ttp.ui.timeplot.curves) == 1
+    assert len(ttp.timechart.chart.curves) == 1
     ttp.remove_curve(sim_signal.name)
-    assert ttp.ui.live_channels.layout().count() == 1  # 1 is a spacer
-    assert len(ttp.ui.timeplot.curves) == 0
+    assert len(ttp.timechart.chart.curves) == 0
 
 def test_curve_creation_button(qtbot, sim_signal):
     ttp = TyphonTimePlot()
@@ -79,12 +64,12 @@ def test_curve_creation_button(qtbot, sim_signal):
     ttp.creation_requested()
     # Check that our signal is stored in the mapping
     assert 'Sim Signal' in ttp.channel_map
-    assert len(ttp.ui.timeplot.curves) == 1
+    assert len(ttp.timechart.chart.curves) == 1
 
 def test_device_plot(motor, qtbot):
     dtp = TyphonTimePlot.from_device(motor)
     qtbot.addWidget(dtp)
     # Add the hint
-    assert len(dtp.ui.timeplot.curves) == 1
+    assert len(dtp.timechart.chart.curves) == 1
     # Added all the signals
-    assert dtp.ui.signal_combo.count() == len(motor.component_names)
+    assert dtp.signal_combo.count() == len(motor.component_names)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -19,6 +19,8 @@ from qtpy.QtGui import QColor
 ##########
 from typhon import register_signal
 from typhon.tools.plot import TyphonTimePlot, DeviceTimePlot
+from typhon.utils import channel_from_signal
+
 
 @pytest.fixture(scope='session')
 def sim_signal():
@@ -47,14 +49,14 @@ def test_curve_methods(qtbot, sim_signal):
     qtbot.addWidget(ttp)
     ttp.add_curve('sig://' + sim_signal.name, name=sim_signal.name)
     # Check that our signal is stored in the mapping
-    assert sim_signal.name in ttp.channel_map
+    assert 'sig://' + sim_signal.name in ttp.channel_map
     # Check that our curve is live
     assert len(ttp.timechart.chart.curves) == 1
     # Try and add again
     ttp.add_curve('sig://' + sim_signal.name, name=sim_signal.name)
     # Check we didn't duplicate
     assert len(ttp.timechart.chart.curves) == 1
-    ttp.remove_curve(sim_signal.name)
+    ttp.remove_curve(channel_from_signal(sim_signal))
     assert len(ttp.timechart.chart.curves) == 0
 
 def test_curve_creation_button(qtbot, sim_signal):
@@ -63,7 +65,7 @@ def test_curve_creation_button(qtbot, sim_signal):
     ttp.add_available_signal(sim_signal, 'Sim Signal')
     ttp.creation_requested()
     # Check that our signal is stored in the mapping
-    assert 'Sim Signal' in ttp.channel_map
+    assert channel_from_signal(sim_signal) in ttp.channel_map
     assert len(ttp.timechart.chart.curves) == 1
 
 def test_device_plot(motor, qtbot):

--- a/typhon/tools/plot.py
+++ b/typhon/tools/plot.py
@@ -4,59 +4,32 @@ Typhon Plotting Interface
 ############
 # Standard #
 ############
-import os.path
 import logging
-from functools import partial
 from warnings import warn
 
 ###############
 # Third Party #
 ###############
 from ophyd import Device
-
-from qtpy import uic
-from qtpy.QtCore import Qt, Slot
-from qtpy.QtGui import QBrush
-from qtpy.QtWidgets import QApplication, QWidget
-
+from timechart.displays.main_display import TimeChartDisplay
+from timechart.utilities.utils import random_color
+from qtpy.QtCore import Slot
+from qtpy.QtWidgets import (QComboBox, QPushButton, QLabel, QVBoxLayout,
+                            QHBoxLayout)
 ##########
 # Module #
 ##########
-from ..utils import (ui_dir, channel_from_signal, clean_attr, random_color,
-                     clean_name, TyphonBase)
+from ..utils import channel_from_signal, clean_attr, clean_name, TyphonBase
 
 logger = logging.getLogger(__name__)
-
-
-class ChannelDisplay(QWidget):
-    """
-    Display for a PyDM PlotCurveItem
-
-    Parameters
-    ----------
-    name : str
-        Alias of channel
-
-    color: QColor
-        Color of curve in plot
-    """
-    def __init__(self, name, color, parent=None):
-        super().__init__(parent=parent)
-        self.ui = uic.loadUi(os.path.join(ui_dir, 'plotitem.ui'), self)
-        self.ui.name.setText(name)
-        self.ui.color.brush = QBrush(color, Qt.SolidPattern)
 
 
 class TyphonTimePlot(TyphonBase):
     """
     Generalized widget for plotting Ophyd signals
 
-    This widget initializes a blank ``PyDMTimePlot`` with a small interface to
-    configure the plotted signals. The list of signals available to the
-    operator can be controlled via :meth:`.add_available_signal`. Shortcuts can
-    be added to the plot itself via :meth:`.add_curve` or the
-    :meth:`.creation_requested` ``Slot`` which takes the current status of
-    the requested combinations
+    This widget is a ``TimeChartDisplay`` wrapped with some convenient
+    functions for adding signals by their attribute name.
 
     Parameters
     ----------
@@ -64,11 +37,22 @@ class TyphonTimePlot(TyphonBase):
     """
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        # Load generated user interface file
-        self.ui = uic.loadUi(os.path.join(ui_dir, 'plot.ui'), self)
-        # Connect create button
-        self.create_button.clicked.connect(self.creation_requested)
-        # Data structure for name / ChannelDisplay mapping
+        # Setup layout
+        self.setLayout(QVBoxLayout())
+        self.layout().setContentsMargins(2, 2, 2, 2)
+        # Make sure we can add signals
+        self.signal_combo = QComboBox()
+        self.signal_combo_label = QLabel('Available Signals: ')
+        self.signal_create = QPushButton('Connect')
+        self.signal_combo_layout = QHBoxLayout()
+        self.signal_combo_layout.addWidget(self.signal_combo_label, 0)
+        self.signal_combo_layout.addWidget(self.signal_combo, 1)
+        self.signal_combo_layout.addWidget(self.signal_create, 0)
+        self.signal_create.clicked.connect(self.creation_requested)
+        self.layout().addLayout(self.signal_combo_layout)
+        # Add timechart
+        self.timechart = TimeChartDisplay(show_pv_add_panel=False)
+        self.layout().addWidget(self.timechart)
         self.channel_map = dict()
 
     def add_available_signal(self, signal, name):
@@ -85,9 +69,9 @@ class TyphonTimePlot(TyphonBase):
         name: str
             Alias for signal to display in QComboBox
         """
-        self.ui.signal_combo.addItem(name, channel_from_signal(signal))
+        self.signal_combo.addItem(name, channel_from_signal(signal))
 
-    def add_curve(self, channel, name=None, color=None):
+    def add_curve(self, channel, name=None, color=None, **kwargs):
         """
         Add a curve to the plot
 
@@ -103,32 +87,18 @@ class TyphonTimePlot(TyphonBase):
         color: QColor, optional
             Color to display line in plot. If None is given, a QColor will be
             chosen randomly
+
+        kwargs:
+            Passed to ``timechart.add_y_channel``
         """
         name = name or channel
-        # Do not allow duplicate channels
-        if name in self.channel_map:
-            logger.error("%r already has been added to the plot", name)
-            return
-        logger.debug("Adding %s to plot ...", channel)
         # Create a random color if None is supplied
         if not color:
             color = random_color()
-        # Add to plot
-        self.ui.timeplot.addYChannel(y_channel=channel, color=color,
-                                     name=name, lineStyle=Qt.SolidLine,
-                                     lineWidth=2, symbol=None)
-        # Add a display to the LiveChannel display
-        ch_display = ChannelDisplay(name, color)
-        self.ui.live_channels.layout().insertWidget(0, ch_display)
-        self.channel_map[name] = ch_display
-        # Connect the removal button to the slot
-        ch_display.remove_button.clicked.connect(partial(self.remove_curve,
-                                                         name))
-        # Establish connections for new instance
-        pydm_app = QApplication.instance()
-        pydm_app.establish_widget_connections(self)
-        # Select new random color
-        self.ui.color.brush = QBrush(random_color(), Qt.SolidPattern)
+        logger.debug("Adding %s to plot ...", channel)
+        self.timechart.add_y_channel(pv_name=channel, curve_name=name,
+                                     color=color, **kwargs)
+        self.channel_map = {name: channel}
 
     @Slot()
     def remove_curve(self, name):
@@ -143,12 +113,8 @@ class TyphonTimePlot(TyphonBase):
         """
         if name in self.channel_map:
             logger.debug("Removing %s from DeviceTimePlot ...", name)
-            self.ui.timeplot.removeCurveWithName(name)
-            # Remove ChannelDisplay
-            ch_display = self.channel_map.pop(name)
-            self.ui.live_channels.layout().removeWidget(ch_display)
-            # Destroy ChannelDisplay
-            ch_display.deleteLater()
+            self.timechart.remove_curve(self.channel_map[name])
+            self.channel_map.pop(name)
         else:
             logger.error("Curve %r was not found in DeviceTimePlot", name)
 
@@ -161,11 +127,11 @@ class TyphonTimePlot(TyphonBase):
         call to :meth:`.add_curve`
         """
         # Find requested channel
-        name = self.ui.signal_combo.currentText()
-        idx = self.ui.signal_combo.currentIndex()
-        channel = self.ui.signal_combo.itemData(idx)
+        name = self.signal_combo.currentText()
+        idx = self.signal_combo.currentIndex()
+        channel = self.signal_combo.itemData(idx)
         # Add to the plot
-        self.add_curve(channel, name=name, color=self.ui.color.brush.color())
+        self.add_curve(channel, name=name)
 
     def add_device(self, device):
         """Add a device and it's component signals to the plot"""

--- a/typhon/tools/plot.py
+++ b/typhon/tools/plot.py
@@ -53,7 +53,7 @@ class TyphonTimePlot(TyphonBase):
         # Add timechart
         self.timechart = TimeChartDisplay(show_pv_add_panel=False)
         self.layout().addWidget(self.timechart)
-        self.channel_map = dict()
+        self.channel_map = self.timechart.channel_map
 
     def add_available_signal(self, signal, name):
         """
@@ -98,7 +98,6 @@ class TyphonTimePlot(TyphonBase):
         logger.debug("Adding %s to plot ...", channel)
         self.timechart.add_y_channel(pv_name=channel, curve_name=name,
                                      color=color, **kwargs)
-        self.channel_map = {name: channel}
 
     @Slot()
     def remove_curve(self, name):
@@ -111,12 +110,8 @@ class TyphonTimePlot(TyphonBase):
             Name of the curve to remove. This should match the name given
             during the call of :meth:`.add_curve`
         """
-        if name in self.channel_map:
-            logger.debug("Removing %s from DeviceTimePlot ...", name)
-            self.timechart.remove_curve(self.channel_map[name])
-            self.channel_map.pop(name)
-        else:
-            logger.error("Curve %r was not found in DeviceTimePlot", name)
+        logger.debug("Removing %s from DeviceTimePlot ...", name)
+        self.timechart.remove_curve(name)
 
     @Slot()
     def creation_requested(self):

--- a/typhon/tools/plot.py
+++ b/typhon/tools/plot.py
@@ -96,7 +96,9 @@ class TyphonTimePlot(TyphonBase):
         if not color:
             color = random_color()
         logger.debug("Adding %s to plot ...", channel)
-        self.timechart.add_y_channel(pv_name=channel, curve_name=name,
+        # TODO: Until https://github.com/slaclab/timechart/pull/32 is in
+        # a release, the pv_name and curve_name need to be the same
+        self.timechart.add_y_channel(pv_name=channel, curve_name=channel,
                                      color=color, **kwargs)
 
     @Slot()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Swap out my homebrewed plotting setup for https://github.com/slaclab/timechart. I get to delete quite a bit of code and close three issues regarding plotting improvements. Thanks for your hard work @hmbui and @hhslepicka 

The only addition I made was a combobox at the top of the widget to add signals by their class attribute name. I think this is fine living in `typhon` for now, but if other people want something similar it might be worth putting into `timechart`. It is convenient when you don't want the user to be able to type any signal they want, but instead give them a nice summary of what they care about.

I patched over the fix in https://github.com/slaclab/timechart/pull/32 just because I don't want to wait for a new release, but put a big comment disclaimer there to fix the line when we do.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #75 
Closes #80 
Closes #81 
Closes #100 



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests were preserved where relevant

## Screenshots (if appropriate):
![timechart](https://user-images.githubusercontent.com/25753048/48304519-72315900-e4cf-11e8-8831-fd92281b27d6.gif)
