### PR TITLE
Designer Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ All `-tag` channels have `-dev` counterparts for bleeding edge installations.
 Both `requirements.txt` and optional `dev-requirements.txt` are kept up to date
 as well for those who prefer installation via `pip`
 
+If installed in this manner, in an environment that is not **root**, the
+environment variables will be setup in such a way that the Typhon widgets will
+immediately be available in the `QtDesigner`. Otherwise, see the
+``typhon_env.sh`` script contained in the ``bin`` folder of this repository.
+
 ## Getting Started
 Creating your first ``typhon`` panel for an``ophyd.Device`` only takes two
 lines:

--- a/bin/typhon_designer_plugin.py
+++ b/bin/typhon_designer_plugin.py
@@ -1,0 +1,3 @@
+print("Importing Typhon QtDesigner plugins ...")
+from typhon.designer import *
+

--- a/bin/typhon_env.sh
+++ b/bin/typhon_env.sh
@@ -1,0 +1,5 @@
+#!/usr//bin/env bash
+TYPHON_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+export PYQTDESIGNERPATH="$TYPHON_DIR":$PYQTDESIGNERPATH
+export PYDM_DESIGNER_ONLINE=True
+

--- a/bin/typhon_env.sh
+++ b/bin/typhon_env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-TYPHON_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+TYPHON_DIR=$(python -c 'import typhon; import pathlib; print(pathlib.Path(typhon.__file__).parent)')
 export PYQTDESIGNERPATH="$TYPHON_DIR":$PYQTDESIGNERPATH
 export PYDM_DESIGNER_ONLINE=True
 

--- a/bin/typhon_env.sh
+++ b/bin/typhon_env.sh
@@ -1,4 +1,4 @@
-#!/usr//bin/env bash
+#!/usr/bin/env bash
 TYPHON_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 export PYQTDESIGNERPATH="$TYPHON_DIR":$PYQTDESIGNERPATH
 export PYDM_DESIGNER_ONLINE=True

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,1 +1,23 @@
+# Install the package
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+
+# Create auxillary
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+mkdir -p $PREFIX/etc/typhon
+
+# Create auxiliary vars
+DESIGNER_PLUGIN_PATH=$PREFIX/etc/typhon
+DESIGNER_PLUGIN=$DESIGNER_PLUGIN_PATH/typhon_designer_plugin.py
+ACTIVATE=$PREFIX/etc/conda/activate.d/typhon.sh
+DEACTIVATE=$PREFIX/etc/conda/deactivate.d/typhon.sh
+
+echo "from typhon.designer import *" >> $DESIGNER_PLUGIN
+echo "export PYQTDESIGNERPATH="$DESIGNER_PLUGIN_PATH":$PYQTDESIGNERPATH" >> $ACTIVATE
+echo "export PYDM_DESIGNER_ONLINE=True" >> $ACTIVATE
+echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE
+
+unset DESIGNER_PLUGIN_PATH
+unset DESIGNER_PLUGIN
+unset ACTIVATE
+unset DEACTIVATE

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
+import os
+
 from qtpy.QtWidgets import QWidget
 from ophyd import Device, Component as Cpt, Kind
+import pytest
 
+import typhon
 from typhon.utils import use_stylesheet, clean_name, grab_hints, grab_kind
 
 
@@ -43,3 +47,13 @@ def test_grab_kind(motor):
                - len(motor.read_attrs)
                - len(motor.configuration_attrs))
     assert len(grab_kind(motor, 'omitted')) == omitted
+
+
+conda_prefix = os.getenv("CONDA_PREFIX")
+
+
+@pytest.mark.skipif(not (conda_prefix and
+                         typhon.__file__.startswith(conda_prefix)),
+                    reason='Package not installed via CONDA')
+def test_qtdesigner_env():
+    assert 'etc/typhon' in os.getenv('PYQTDESIGNERPATH', '')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If installed via CONDA, `typhon` widgets will now automatically be available in Designer. For development, the `typhon_env.sh` script can be used to set everything up as well. The PYDM_DESIGNER_ONLINE variable is set up as well, otherwise the Typhon widgets will not update as you change parameters.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #129 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test will be run if we believe the package to be installed via CONDA
