### PR TITLE
TyphonDisplay API

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -43,15 +43,17 @@ def test_device_display_templates(motor, qtbot):
     assert panel.current_template == panel.default_templates['embedded_screen']
     # Force a specific template
     eng_ui = panel.default_templates['engineering_screen']
-    panel.use_template = eng_ui
-    assert panel.use_template == eng_ui
+    panel.embedded_template = eng_ui
+    assert panel.embedded_template == eng_ui
     assert panel.current_template == eng_ui
     # Check that if we pass in a template as macros we use the forced template
     panel.load_template(macros={'embedded_screen': 'tst.ui'})
     assert panel.current_template == eng_ui
+    # But if we don't specify any template use macros
+    panel.embedded_template = ''
+    assert panel.current_template == 'tst.ui'
     panel.use_default_templates = True
     assert panel.use_default_templates
-    panel.use_template = ''
     panel.load_template(macros={'embedded_screen': 'tst.ui'})
     assert panel.current_template == panel.default_templates['embedded_screen']
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,18 @@
 import os.path
+
+import pytest
+
 from typhon import TyphonDisplay
 from typhon.utils import clean_attr
+
 from .conftest import show_widget
+
+
+@pytest.fixture(scope='function')
+def display(qtbot):
+    display = TyphonDisplay()
+    qtbot.addWidget(display)
+    return display
 
 
 @show_widget
@@ -31,32 +42,38 @@ def test_device_display(device, motor, qtbot):
     return panel
 
 
-def test_device_display_templates(motor, qtbot):
-    panel = TyphonDisplay()
-    qtbot.addWidget(panel)
+def test_display_without_md(motor, display):
     # Add a generic motor
-    panel.add_device(motor)
-    assert panel.devices[0] == motor
-    assert panel.current_template == panel.default_templates['detailed_screen']
-    # Changing template type changes template
-    panel.template_type = panel.embedded_screen
-    assert panel.current_template == panel.default_templates['embedded_screen']
-    # Force a specific template
-    eng_ui = panel.default_templates['engineering_screen']
-    panel.embedded_template = eng_ui
-    assert panel.embedded_template == eng_ui
-    assert panel.current_template == eng_ui
-    # Check that if we pass in a template as macros we use the forced template
-    panel.load_template(macros={'embedded_screen': 'tst.ui'})
-    assert panel.current_template == eng_ui
-    # But if we don't specify any template use macros
-    panel.embedded_template = ''
-    assert panel.current_template == 'tst.ui'
-    panel.use_default_templates = True
-    assert panel.use_default_templates
-    panel.load_template(macros={'embedded_screen': 'tst.ui'})
-    assert panel.current_template == panel.default_templates['embedded_screen']
+    display.add_device(motor)
+    assert display.devices[0] == motor
+    assert display.current_template == display.templates['detailed_screen']
 
+
+def test_display_with_md(motor, display):
+    display.load_template(macros={'detailed_screen': 'tst.ui'})
+    assert display.current_template == 'tst.ui'
+    assert display.templates['detailed_screen'] == 'tst.ui'
+
+
+def test_display_type_change(display):
+    # Changing template type changes template
+    display.display_type = display.embedded_screen
+    assert display.current_template == display.templates['embedded_screen']
+
+
+def test_display_modified_templates(display, motor):
+    display.add_device(motor)
+    eng_ui = display.templates['engineering_screen']
+    display.templates['embedded_screen'] = eng_ui
+    display.display_type = display.embedded_screen
+    assert display.current_template == eng_ui
+
+
+def test_display_force_template(display):
+    # Check that we use the forced template
+    display.force_template = 'tst.ui'
+    assert display.force_template == 'tst.ui'
+    assert display.current_template == 'tst.ui'
 
 def test_display_with_channel(client, qtbot):
     panel = TyphonDisplay()

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -68,7 +68,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
 
     def __init__(self,  parent=None, **kwargs):
         # Intialize background variable
-        self._use_default = False
+        self._forced_template = ''
         self._last_macros = dict()
         self._main_widget = None
         self._templates = dict.fromkeys(self.default_templates, '')
@@ -138,6 +138,17 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
             self._main_widget = QWidget()
         finally:
             self.layout().addWidget(self._main_widget)
+
+    @Property(str)
+    def force_template(self):
+        """Force a specific template"""
+        return self._forced_template
+
+    @force_template.setter
+    def force_template(self, value):
+        if value != self._forced_template:
+            self._forced_template = value
+            self.load_template()
 
     def add_device(self, device, macros=None):
         """

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -62,17 +62,16 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
     # Template types and defaults
     Q_ENUMS(TemplateTypes)
     TemplateEnum = TemplateTypes.to_enum()  # For convenience
-    default_templates = dict((_typ.name, os.path.join(ui_dir,
-                                                      _typ.name + '.ui'))
-                             for _typ in TemplateEnum)
 
     def __init__(self,  parent=None, **kwargs):
         # Intialize background variable
         self._forced_template = ''
         self._last_macros = dict()
         self._main_widget = None
-        self._templates = dict.fromkeys(self.default_templates, '')
         self._template_type = TemplateTypes.detailed_screen
+        self.templates = dict((_typ.name, os.path.join(ui_dir,
+                                                      _typ.name + '.ui'))
+                              for _typ in self.TemplateEnum)
         # Set this to None first so we don't render
         super().__init__(parent=parent)
         # Initialize blank UI
@@ -125,6 +124,13 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
             clear_layout(self.layout())
         # Assemble our macros
         macros = macros or dict()
+        for template_type in self.templates:
+            value = macros.get(template_type)
+            if value:
+                logger.debug("Found new template %r for %r",
+                             value, template_type)
+                self.templates[template_type] = value
+        # Store macros
         self._last_macros = macros
         try:
             self._main_widget = Display(ui_filename=self.current_template,

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -107,18 +107,6 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
             self._template_type = value
             self.load_template(macros=self._last_macros)
 
-    @Property(bool)
-    def use_default_templates(self):
-        """Use the default Typhon template instead of a device specific"""
-        return self._use_default
-
-    @use_default_templates.setter
-    def use_default_templates(self, value):
-        if value != self._use_default:
-            self._use_default = value
-            # Reload template with last known set of macros
-            self.load_template(macros=self._last_macros)
-
     def load_template(self, macros=None):
         """
         Load a new template
@@ -205,43 +193,10 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
         display = cls()
         # Reset the template if provided
         if template:
-            display.detailed_template = template
+            display.force_template = template
         # Add the device
         display.add_device(device, macros=macros)
         return display
-
-    def _get_template(self, tmp_typ):
-        template_key = self.TemplateEnum(tmp_typ).name
-        return self._templates.get(template_key)
-
-    def _set_template(self, value, tmp_typ):
-        if self._get_template(tmp_typ) != value:
-            template_key = self.TemplateEnum(tmp_typ).name
-            self._templates[template_key] = value
-            # If this will affect the current view, reload
-            if self.current_template == value:
-                self.load_template(macros=self._last_macros)
-
-    detailed_template = Property(
-                            str,
-                            partial(_get_template,
-                                    tmp_typ=TemplateTypes.detailed_screen),
-                            partial(_set_template,
-                                    tmp_typ=TemplateTypes.detailed_screen))
-
-    embedded_template = Property(
-                            str,
-                            partial(_get_template,
-                                    tmp_typ=TemplateTypes.embedded_screen),
-                            partial(_set_template,
-                                    tmp_typ=TemplateTypes.embedded_screen))
-
-    engineering_template = Property(
-                            str,
-                            partial(_get_template,
-                                    tmp_typ=TemplateTypes.engineering_screen),
-                            partial(_set_template,
-                                    tmp_typ=TemplateTypes.engineering_screen))
 
     @Slot(object)
     def _tx(self, value):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -83,17 +83,11 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
     @property
     def current_template(self):
         """Current template being rendered"""
+        if self._forced_template:
+            return self._forced_template
         # Search in the last macros, maybe our device told us what to do
         template_key = self.TemplateEnum(self._template_type).name
-        provided_template = self._templates[template_key]
-        metadata_template = self._last_macros.get(template_key)
-        if self._use_default or (not provided_template and not
-                                 metadata_template):
-            return self.default_templates[template_key]
-        elif provided_template:
-            return provided_template
-        else:
-            return metadata_template
+        return self.templates[template_key]
 
     @Property(TemplateTypes)
     def template_type(self):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -145,7 +145,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
             if self.devices:
                 for widget in self._main_widget.findChildren(TyphonBase):
                     widget.add_device(self.devices[0])
-        except FileNotFoundError:
+        except (FileNotFoundError, IsADirectoryError):
             logger.exception("Unable to load file %r", self.current_template)
             self._main_widget = QWidget()
         finally:

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -14,7 +14,7 @@ from .widgets import TyphonDesignerMixin
 logger = logging.getLogger(__name__)
 
 
-class TemplateTypes:
+class DisplayTypes:
     """Types of Available Templates"""
     embedded_screen = 0
     detailed_screen = 1
@@ -30,7 +30,7 @@ class TemplateTypes:
         return Enum('TemplateEnum', entries)
 
 
-class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
+class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     """
     Main Panel display for a signal Ophyd Device
 
@@ -60,15 +60,15 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
     parent: QWidget, optional
     """
     # Template types and defaults
-    Q_ENUMS(TemplateTypes)
-    TemplateEnum = TemplateTypes.to_enum()  # For convenience
+    Q_ENUMS(DisplayTypes)
+    TemplateEnum = DisplayTypes.to_enum()  # For convenience
 
     def __init__(self,  parent=None, **kwargs):
         # Intialize background variable
         self._forced_template = ''
         self._last_macros = dict()
         self._main_widget = None
-        self._template_type = TemplateTypes.detailed_screen
+        self._display_type = DisplayTypes.detailed_screen
         self.templates = dict((_typ.name, os.path.join(ui_dir,
                                                       _typ.name + '.ui'))
                               for _typ in self.TemplateEnum)
@@ -86,18 +86,18 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
         if self._forced_template:
             return self._forced_template
         # Search in the last macros, maybe our device told us what to do
-        template_key = self.TemplateEnum(self._template_type).name
+        template_key = self.TemplateEnum(self._display_type).name
         return self.templates[template_key]
 
-    @Property(TemplateTypes)
-    def template_type(self):
-        return self._template_type
+    @Property(DisplayTypes)
+    def display_type(self):
+        return self._display_type
 
-    @template_type.setter
-    def template_type(self, value):
+    @display_type.setter
+    def display_type(self, value):
         # Store our new value
-        if self._template_type != value:
-            self._template_type = value
+        if self._display_type != value:
+            self._display_type = value
             self.load_template(macros=self._last_macros)
 
     def load_template(self, macros=None):
@@ -118,12 +118,12 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
             clear_layout(self.layout())
         # Assemble our macros
         macros = macros or dict()
-        for template_type in self.templates:
-            value = macros.get(template_type)
+        for display_type in self.templates:
+            value = macros.get(display_type)
             if value:
                 logger.debug("Found new template %r for %r",
-                             value, template_type)
-                self.templates[template_type] = value
+                             value, display_type)
+                self.templates[display_type] = value
         # Store macros
         self._last_macros = macros
         try:

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -67,7 +67,6 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
 
     def __init__(self,  parent=None, **kwargs):
         # Intialize background variable
-        self._use_template = ''
         self._use_default = False
         self._last_macros = dict()
         self._main_widget = None
@@ -83,9 +82,6 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
     @property
     def current_template(self):
         """Current template being rendered"""
-        # If a user forces a template we use it
-        if self._use_template:
-            return self._use_template
         # Search in the last macros, maybe our device told us what to do
         template_key = self.TemplateEnum(self._template_type).name
         if not self._use_default and self._last_macros.get(template_key, None):
@@ -102,20 +98,6 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
         # Store our new value
         if self._template_type != value:
             self._template_type = value
-            # Reload the template if it will affect the final product
-            if not self._use_template:
-                self.load_template(macros=self._last_macros)
-
-    @Property(str)
-    def use_template(self):
-        """Use this template regardless of any other setting"""
-        return self._use_template
-
-    @use_template.setter
-    def use_template(self, value):
-        if value != self._use_template:
-            self._use_template = value
-            # Reload template with last known set of macros
             self.load_template(macros=self._last_macros)
 
     @Property(bool)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from functools import partial
 import logging
 import os.path
 
@@ -70,7 +69,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
         self._main_widget = None
         self._display_type = DisplayTypes.detailed_screen
         self.templates = dict((_typ.name, os.path.join(ui_dir,
-                                                      _typ.name + '.ui'))
+                                                       _typ.name + '.ui'))
                               for _typ in self.TemplateEnum)
         # Set this to None first so we don't render
         super().__init__(parent=parent)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -4,7 +4,7 @@ import os.path
 
 from pydm import Display
 from qtpy.QtCore import Property, Slot, Q_ENUMS
-from qtpy.QtWidgets import QHBoxLayout
+from qtpy.QtWidgets import QHBoxLayout, QWidget
 
 from .utils import ui_dir, TyphonBase, clear_layout
 from .widgets import TyphonDesignerMixin
@@ -131,13 +131,18 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, TemplateTypes):
         # Assemble our macros
         macros = macros or dict()
         self._last_macros = macros
-        self._main_widget = Display(ui_filename=self.current_template,
-                                    macros=macros)
-        self.layout().addWidget(self._main_widget)
-        # Add device to all children widgets
-        if self.devices:
-            for widget in self._main_widget.findChildren(TyphonBase):
-                widget.add_device(self.devices[0])
+        try:
+            self._main_widget = Display(ui_filename=self.current_template,
+                                        macros=macros)
+            # Add device to all children widgets
+            if self.devices:
+                for widget in self._main_widget.findChildren(TyphonBase):
+                    widget.add_device(self.devices[0])
+        except FileNotFoundError:
+            logger.exception("Unable to load file %r", self.current_template)
+            self._main_widget = QWidget()
+        finally:
+            self.layout().addWidget(self._main_widget)
 
     def add_device(self, device, macros=None):
         """

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -270,7 +270,7 @@ class TyphonSuite(TyphonBase):
         """Tools loaded into the DeviceDisplay"""
         return [param.value() for param in self._tool_group.childs]
 
-    def add_device(self, device, children=True, methods=None, image=None):
+    def add_device(self, device, children=True):
         """
         Add a device to the :attr:`.device_panel` and tools
 
@@ -281,14 +281,9 @@ class TyphonSuite(TyphonBase):
         methods: list, optional
             Methods to add to the device
         """
-        methods = methods or list()
         super().add_device(device)
         # Create DeviceParameter
         dev_param = DeviceParameter(device, subdevices=children)
-        for method in methods:
-            dev_param.value.add_method(method)
-        if image:
-            dev_param.value.add_image(image)
         # Attach signals
         all_params = [dev_param] + dev_param.childs
         for param in all_params:


### PR DESCRIPTION
Played around with the API of `TyphonDisplay` today, trying to put it in a `TyphonSuite`, and it really was awkward. I think this solution is a lot more intuitive. What you really want to do is not just specify a static template but specify a template for each kind of display (if you aren't already using `happi`). That way you still get the full feature set of swapping around the `TemplateType` but you can modify the behavior at whichever stage you deem necessary. For instance, the situation where you wanted a custom embedded template but wanted to use the other defaults was hard to specify in the old API.

## Changes
`use_template`is gone, instead there are just properties for each type `embedded_template`, `display_template` e.t.c. The template priority that is used is as follows:

1. If `use_default_templates` is forced we use the default template shipped with `Typhon`
2. If a template is provided in the corresponding property we use it
3. If a template is provided in the `happi` metdata, we use it.
4.  Otherwise, use the default.

Also, `image` and `methods` were removed in the PR but there were still explicit keywords for these in `TyphonSuite`. These have been removed.