### PR TITLE
Device Categories

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -5,6 +5,7 @@
 ############
 # External #
 ############
+import pytest
 from pyqtgraph.parametertree import ParameterTree, parameterTypes as ptypes
 from qtpy.QtWidgets import QDockWidget
 
@@ -16,31 +17,37 @@ from typhon.suite import TyphonSuite, DeviceParameter
 from .conftest import show_widget
 
 
-@show_widget
-def test_suite(device):
-    device.name = 'test'
+@pytest.fixture(scope='function')
+def suite(qtbot, device):
     suite = TyphonSuite.from_device(device)
-    assert device in suite.devices
-    # Grab all device displays
-    assert len(suite._device_group.childs) == 1
-    child_displays = suite._device_group.childs[0].childs
-    assert len(child_displays) == len(device._sub_devices)
-    # Default tools are loaded
-    assert len(suite.tools) == 3
-    assert len(suite.tools[0].devices) == 1
-    # No children
-    childless = TyphonSuite.from_device(device, children=False)
-    # Grab all device displays
-    childless_displays = childless._device_group.childs[0].childs
-    assert len(childless_displays) == 0
+    qtbot.addWidget(suite)
     return suite
 
 
 @show_widget
-def test_suite_subdisplay(qapp, qtbot, device):
-    # Set display by Device component
-    suite = TyphonSuite.from_device(device)
-    qtbot.addWidget(suite)
+def test_suite_with_child_devices(suite, device):
+    assert device in suite.devices
+    device_group = suite.top_level_groups[0]
+    assert len(device_group.childs) == 1
+    child_displays = device_group.childs[0].childs
+    assert len(child_displays) == len(device._sub_devices)
+    return suite
+
+def test_suite_without_children(device, qtbot):
+    childless = TyphonSuite.from_device(device, children=False)
+    qtbot.addWidget(childless)
+    device_group = childless.top_level_groups[0]
+    childless_displays = device_group.childs[0].childs
+    assert len(childless_displays) == 0
+
+
+def test_suite_tools(suite):
+    assert len(suite.tools) == 3
+    assert len(suite.tools[0].devices) == 1
+
+
+def test_suite_subdisplay(qtbot, suite):
+    device = suite.devices[0]
     x_display = suite.get_subdisplay(device.x)
     assert device.x in x_display.devices
     suite.show_subdisplay(device.x)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -27,7 +27,7 @@ def suite(qtbot, device):
 @show_widget
 def test_suite_with_child_devices(suite, device):
     assert device in suite.devices
-    device_group = suite.top_level_groups[0]
+    device_group = suite.top_level_groups['Devices']
     assert len(device_group.childs) == 1
     child_displays = device_group.childs[0].childs
     assert len(child_displays) == len(device._sub_devices)
@@ -36,7 +36,7 @@ def test_suite_with_child_devices(suite, device):
 def test_suite_without_children(device, qtbot):
     childless = TyphonSuite.from_device(device, children=False)
     qtbot.addWidget(childless)
-    device_group = childless.top_level_groups[0]
+    device_group = childless.top_level_groups['Devices']
     childless_displays = device_group.childs[0].childs
     assert len(childless_displays) == 0
 
@@ -64,7 +64,7 @@ def test_suite_show_display_by_device(suite, device):
 
 
 def test_suite_show_display_by_parameter(suite):
-    device_param = suite.top_level_groups[0].childs[0]
+    device_param = suite.top_level_groups['Devices'].childs[0]
     suite.show_subdisplay(device_param)
     dock = suite.layout().itemAt(suite.layout().count() - 1).widget()
     assert isinstance(dock, QDockWidget)
@@ -81,7 +81,7 @@ def test_suite_hide_subdisplay_by_device(suite, device, qtbot):
 
 
 def test_suite_hide_subdisplay_by_parameter(suite, qtbot):
-    device_param = suite.top_level_groups[0].childs[0]
+    device_param = suite.top_level_groups['Devices'].childs[0]
     suite.show_subdisplay(device_param)
     display = suite.get_subdisplay(device_param.device)
     suite.show_subdisplay(device_param)

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -3,15 +3,13 @@
 ############
 from functools import partial
 import logging
-import warnings
 
 ############
 # External #
 ############
 from pyqtgraph.parametertree import ParameterTree, parameterTypes as ptypes
-from ophyd import Device
 from qtpy.QtCore import Signal, Slot, Qt
-from qtpy.QtWidgets import QDockWidget, QListWidgetItem, QHBoxLayout, QWidget
+from qtpy.QtWidgets import QDockWidget, QHBoxLayout, QWidget
 
 ###########
 # Package #
@@ -114,7 +112,6 @@ class TyphonSuite(TyphonBase):
         parameter = SidebarParameter(value=display, name=name)
         return self._add_to_sidebar(parameter, category)
 
-
     @property
     def top_level_groups(self):
         """All top-level groups expressed as ``QGroupParameterItem`` objects"""
@@ -163,7 +160,7 @@ class TyphonSuite(TyphonBase):
             tree = flatten_tree(group)
             for param in tree:
                 match = (display in getattr(param.value(), 'devices', [])
-                         or param.name()== display)
+                         or param.name() == display)
                 if match:
                     return param.value()
         # If we got here we can't find the subdisplay

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -105,7 +105,7 @@ class TyphonSuite(TyphonBase):
         """
         # Create our parameter
         parameter = SidebarParameter(value=display, name=name)
-        return self._add_to_sidebar(parameter, category)
+        self._add_to_sidebar(parameter, category)
 
     @property
     def top_level_groups(self):
@@ -132,7 +132,7 @@ class TyphonSuite(TyphonBase):
         tool: QWidget
             Widget to be added to ``.ui.subdisplay``
         """
-        return self.add_subdisplay(name, tool, 'Tools')
+        self.add_subdisplay(name, tool, 'Tools')
 
     def get_subdisplay(self, display):
         """
@@ -268,7 +268,6 @@ class TyphonSuite(TyphonBase):
             except Exception:
                 logger.exception("Unable to add %s to tool %s",
                                  device.name, type(tool))
-        return dev_param
 
     @classmethod
     def from_device(cls, device, parent=None,
@@ -300,8 +299,8 @@ class TyphonSuite(TyphonBase):
                 display.add_tool(name, tool())
             except Exception:
                 logger.exception("Unable to load %s", type(tool))
-        param = display.add_device(device, **kwargs)
-        display.show_subdisplay(param)
+        display.add_device(device, **kwargs)
+        display.show_subdisplay(device)
         return display
 
     def _add_to_sidebar(self, parameter, category=None):

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -86,9 +86,6 @@ class TyphonSuite(TyphonBase):
         # Create device group
         self._device_group = ptypes.GroupParameter(name='Devices')
         self._tree.addParameters(self._device_group)
-        # Create tool group
-        self._tool_group = ptypes.GroupParameter(name='Tools')
-        self._tree.addParameters(self._tool_group)
         # Setup layout
         self._layout = QHBoxLayout()
         self._layout.setSizeConstraint(QHBoxLayout.SetFixedSize)
@@ -140,10 +137,7 @@ class TyphonSuite(TyphonBase):
         tool: QWidget
             Widget to be added to ``.ui.subdisplay``
         """
-        tool_param = SidebarParameter(value=tool, name=name)
-        self._tool_group.addChild(tool_param)
-        self._add_to_sidebar(tool_param)
-        return tool_param
+        return self.add_subdisplay(name, tool, 'Tools')
 
     def get_subdisplay(self, display):
         """

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -95,7 +95,7 @@ class TyphonSuite(TyphonBase):
         self._layout.addWidget(self._tree)
         self.setLayout(self._layout)
 
-    def add_subdisplay(self, name, display, list_widget):
+    def add_subdisplay(self, name, display, category):
         """
         Add a widget to one of the button layouts
 
@@ -116,12 +116,9 @@ class TyphonSuite(TyphonBase):
             QWidget with the PyQtSignal ``clicked``. If None, is given a
             QPushButton is created
         """
-        warnings.warn("This method is deprecated. Use TyphonSuite.add_device "
-                      "or TyphonSuite.add_tool instead.")
-        # Create QListViewItem to store the display information
-        list_item = QListWidgetItem(name)
-        list_item.setData(Qt.UserRole, display)
-        list_widget.addItem(list_item)
+        # Create our parameter
+        parameter = SidebarParameter(value=display, name=name)
+        return self._add_to_sidebar(parameter, category)
 
 
     @property

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -103,6 +103,8 @@ class TyphonSuite(TyphonBase):
             The top level group to place the controls under in the tree. If the
             category does not exist, a new one will be made
         """
+        logger.debug("Adding widget %r with %r to %r ...",
+                     name, display, category)
         # Create our parameter
         parameter = SidebarParameter(value=display, name=name)
         self._add_to_sidebar(parameter, category)
@@ -191,6 +193,7 @@ class TyphonSuite(TyphonBase):
         elif not isinstance(widget, QWidget):
             widget = self.get_subdisplay(widget)
         # Add the widget to the dock
+        logger.debug("Showing widget %r ...", widget)
         dock.setWidget(widget)
         # Add to layout
         self.layout().addWidget(dock)
@@ -216,7 +219,9 @@ class TyphonSuite(TyphonBase):
         elif not isinstance(widget, QWidget):
             widget = self.get_subdisplay(widget)
         # Make sure the actual widget is hidden
+        logger.debug("Hiding widget %r ...", widget)
         if isinstance(widget.parent(), QDockWidget):
+            logger.debug("Closing dock ...")
             widget.parent().close()
         else:
             widget.hide()

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -309,7 +309,7 @@ class TyphonSuite(TyphonBase):
         return display
 
     def _add_to_sidebar(self, parameter, category=None):
-        """Add an item to the sidebar, connecting neccesary signals"""
+        """Add an item to the sidebar, connecting necessary signals"""
         if category:
             # Create or grab our category
             group_dict = dict((param.name(), param)

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -159,21 +159,15 @@ class TyphonSuite(TyphonBase):
             my_display.get_subdisplay(my_device.x)
             my_display.get_subdisplay('My Tool')
         """
-        # Get the cleaned Device name if passed a Device
-        if isinstance(display, Device):
-            tree = flatten_tree(self._device_group)
+        for group in self.top_level_groups:
+            tree = flatten_tree(group)
             for param in tree:
-                if display in getattr(param.value(), 'devices', []):
-                    return param.value()
-        # Otherwise we could be looking for either a tool or device
-        else:
-            tree = (flatten_tree(self._device_group)
-                    + flatten_tree(self._tool_group))
-            for param in tree:
-                if param.name() == display:
+                match = (display in getattr(param.value(), 'devices', [])
+                         or param.name()== display)
+                if match:
                     return param.value()
         # If we got here we can't find the subdisplay
-        raise ValueError("Unable to find subdisplay %r", display)
+        raise ValueError(f"Unable to find subdisplay {display}")
 
     @Slot(str)
     @Slot(object)

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -122,21 +122,8 @@ class TyphonSuite(TyphonBase):
         list_item = QListWidgetItem(name)
         list_item.setData(Qt.UserRole, display)
         list_widget.addItem(list_item)
-    def add_subdevice(self, device, name=None, **kwargs):
-        """
-        Add a subdevice to the `component_widget` stack
 
-        Parameters
-        ----------
-        device : ophyd.Device
 
-        kwargs:
-            Passed to :meth:`.TyphonSuite.add_device`
-        """
-        warnings.warn("This method is deprecated. "
-                      "Use `TyphonSuite.add_device`")
-        logger.debug("Creating subdisplay for %s", device.name)
-        self.add_device(device, **kwargs)
     @property
     def top_level_groups(self):
         """All top-level groups expressed as ``QGroupParameterItem`` objects"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The goal is to be more flexible with how we add widgets to the sidebar. Before we had one category for "Devices" one for "Tools" and and that was it. In reality, if you get more than a few devices in the suite you may want to start breaking this up into more fine grain categories (below motion and diagnostics are separated). 

In order to accommodate this I had to change how we searched through the `ParameterTree` to find relevant object and keep the docking status inline with the tree button.

I also had deprecated the `add_subdevice` method. But in line with other PRs I don't want to keep that kind of flotsam around this early in the project so it is officially gone.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #133 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Revamped test suite for TyphonSuite 😄  Unit tests are more unit-like

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Updated docstrings as well


## Screenshots (if appropriate):
![categories](https://user-images.githubusercontent.com/25753048/49765543-ab541900-fc87-11e8-887d-1ae2e966e53e.gif)

