### PR TITLE
Embedded Windows in Suite

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 
     print('pytest arguments: {}'.format(args))
 
-    root_logger = logging.getLogger()
+    root_logger = logging.getLogger('typhon')
     root_logger.setLevel(logging.DEBUG)
     log_dir = Path(os.path.dirname(__file__)) / 'logs'
     log_file = log_dir / 'run_tests_log.txt'

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -114,3 +114,23 @@ def test_device_parameter_tree(qtbot, motor, device):
     dev_param = DeviceParameter(device, emeddable=True)
     assert len(dev_param.childs) == len(device._sub_devices)
     devices.addChild(dev_param)
+
+
+def test_suite_embed_device(suite, device):
+    suite.embed_subdisplay(device.x)
+    dock_layout = suite.embedded_dock.widget().layout()
+    assert dock_layout.itemAt(0).widget().devices[0] == device.x
+
+
+def test_suite_embed_device_by_name(suite, device):
+    suite.embed_subdisplay(device.name)
+    dock_layout = suite.embedded_dock.widget().layout()
+    assert dock_layout.itemAt(0).widget().devices[0] == device
+
+
+def test_hide_embedded_display(suite, device):
+    suite.embed_subdisplay(device.x)
+    suite.hide_subdisplay(device.x)
+    display = suite.get_subdisplay(device.x)
+    assert suite.embedded_dock is None
+    assert display.isHidden()

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -19,7 +19,7 @@ from .conftest import show_widget
 
 @pytest.fixture(scope='function')
 def suite(qtbot, device):
-    suite = TyphonSuite.from_device(device)
+    suite = TyphonSuite.from_device(device, tools=dict())
     qtbot.addWidget(suite)
     return suite
 
@@ -41,7 +41,8 @@ def test_suite_without_children(device, qtbot):
     assert len(childless_displays) == 0
 
 
-def test_suite_tools(suite):
+def test_suite_tools(device):
+    suite = TyphonSuite.from_device(device)
     assert len(suite.tools) == 3
     assert len(suite.tools[0].devices) == 1
 

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -162,6 +162,8 @@ class TyphonSuite(TyphonBase):
             suite.get_subdisplay(my_device.x)
             suite.get_subdisplay('My Tool')
         """
+        if isinstance(display, SidebarParameter):
+            return display.value()
         for group in self.top_level_groups.values():
             tree = flatten_tree(group)
             for param in tree:
@@ -185,20 +187,18 @@ class TyphonSuite(TyphonBase):
             shown and the sidebar item update. Otherwise, the information is
             passed to :meth:`.get_subdisplay`
         """
+        # Grab true widget
+        if not isinstance(widget, QWidget):
+            widget = self.get_subdisplay(widget)
         # Setup the dock
         dock = SubDisplay(self)
-        # Grab the relevant display
-        if isinstance(widget, SidebarParameter):
-            for item in widget.items:
-                item._mark_shown()
-            # Make sure we react if the dock is closed outside of our menu
-            dock.closing.connect(partial(self.hide_subdisplay,
-                                         widget))
-            widget = widget.value()
-        elif not isinstance(widget, QWidget):
-            widget = self.get_subdisplay(widget)
+        # Set sidebar properly
+        self._show_sidebar(widget, dock)
         # Add the widget to the dock
         logger.debug("Showing widget %r ...", widget)
+        if hasattr(widget, 'display_type'):
+            widget.display_type = widget.detailed_screen
+        widget.setVisible(True)
         dock.setWidget(widget)
         # Add to layout
         self.layout().addWidget(dock)

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -60,9 +60,12 @@ class DeviceParameter(SidebarParameter):
                                             strip_parent=subdevice.root)
                     child_display = TyphonDisplay.from_device(subdevice)
                     children.append(SidebarParameter(value=child_display,
-                                                     name=child_name))
+                                                     name=child_name,
+                                                     embeddable=True))
         opts['children'] = children
-        super().__init__(value=TyphonDisplay.from_device(device), **opts)
+        super().__init__(value=TyphonDisplay.from_device(device),
+                         embeddable=opts.pop('embeddable', True),
+                         **opts)
 
 
 class TyphonSuite(TyphonBase):
@@ -369,4 +372,7 @@ class TyphonSuite(TyphonBase):
                                           parameter))
         parameter.sigHide.connect(partial(self.hide_subdisplay,
                                           parameter))
+        if parameter.embeddable:
+            parameter.sigEmbed.connect(partial(self.embed_subdisplay,
+                                               parameter))
         return parameter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
You now have the option to `embed` an screen in the `TyphonSuite`. Instead of launching a new `QDockWidget` we tile these windows together in a single layout to use space efficiently. This allows operators to toggle the views of their system and the depth they want to see device information.

In code this meant:

* Factoring code out of `show_subdisplay`  into `_show_sidebar`. This function largely does the legwork of making sure that our widget docking system stays in sync with the available actions in the parameter tree
* Creating a `embed_subdisplay` method to setup the layout and `embedded_dock` correctly
* Modify `hide_subdisplay` to handle embedded windows slightly differently.

Also on the side:
* I set the logging setup to only capture `typhon` messages.`PyQt` creating a logging debug message for every parameter on every widget loaded by a `.ui` file. This quickly gets out of hand...
* Something about 8 or more rapid setup and teardowns of the `QtConsole` widget in the `TyphonSuite` tests locks up. I took this tool out of the repeated fixture. I'm hoping to never see this happen in the wild but noting this for posterity's sake.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #132 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added three tests for embedded behavior


## Screenshots (if appropriate):
![embedded](https://user-images.githubusercontent.com/25753048/49892153-225eee00-fdfd-11e8-8d84-583b8e82b147.gif)

