### PR TITLE
Panel and TyphonDisplay Stylesheets

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -81,3 +81,9 @@ def test_display_with_channel(client, qtbot):
     panel.channel = 'happi://test_motor'
     assert panel.channel == 'happi://test_motor'
     assert len(panel.devices) == 1
+
+
+def test_display_device_class_property(motor, display):
+    assert display.device_class == ''
+    display.add_device(motor)
+    assert display.device_class == 'ophyd.sim.SynAxis'

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -87,3 +87,9 @@ def test_display_device_class_property(motor, display):
     assert display.device_class == ''
     display.add_device(motor)
     assert display.device_class == 'ophyd.sim.SynAxis'
+
+
+def test_display_device_name_property(motor, display):
+    assert display.device_name == ''
+    display.add_device(motor)
+    assert display.device_name == motor.name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import os
 
+from qtpy.QtCore import QRect
+from qtpy.QtGui import QPaintEvent
 from qtpy.QtWidgets import QWidget
 from ophyd import Device, Component as Cpt, Kind
 import pytest
@@ -61,4 +63,5 @@ def test_qtdesigner_env():
 
 def test_typhonbase_repaint_smoke():
     tp = TyphonBase()
-    tp.repaint()
+    pe = QPaintEvent(QRect(1, 2, 3, 4))
+    tp.paintEvent(pe)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,8 @@ from ophyd import Device, Component as Cpt, Kind
 import pytest
 
 import typhon
-from typhon.utils import use_stylesheet, clean_name, grab_hints, grab_kind
-
+from typhon.utils import (use_stylesheet, clean_name, grab_hints, grab_kind,
+                          TyphonBase)
 
 class NestedDevice(Device):
     phi = Cpt(Device)
@@ -57,3 +57,8 @@ conda_prefix = os.getenv("CONDA_PREFIX")
                     reason='Package not installed via CONDA')
 def test_qtdesigner_env():
     assert 'etc/typhon' in os.getenv('PYQTDESIGNERPATH', '')
+
+
+def test_typhonbase_repaint_smoke():
+    tp = TyphonBase()
+    tp.repaint()

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -156,7 +156,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     def force_template(self, value):
         if value != self._forced_template:
             self._forced_template = value
-            self.load_template()
+            self.load_template(macros=self._last_macros)
 
     def add_device(self, device, macros=None):
         """

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -146,6 +146,10 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
             self._main_widget = QWidget()
         finally:
             self.layout().addWidget(self._main_widget)
+            # The following code reapplies the stylesheet
+            self.style().unpolish(self)
+            self.style().polish(self)
+            self.update()
 
     @Property(str)
     def force_template(self):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -108,6 +108,13 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
                              device_class.__name__))
         return ''
 
+    @Property(str, designable=False)
+    def device_name(self):
+        "Name of loaded device"
+        if self.devices:
+            return self.devices[0].name
+        return ''
+
     def load_template(self, macros=None):
         """
         Load a new template

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -99,6 +99,15 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
             self._display_type = value
             self.load_template(macros=self._last_macros)
 
+    @Property(str, designable=False)
+    def device_class(self):
+        """Full class with module name of loaded device"""
+        if self.devices:
+            device_class = self.devices[0].__class__
+            return '.'.join((device_class.__module__,
+                             device_class.__name__))
+        return ''
+
     def load_template(self, macros=None):
         """
         Load a new template

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -60,6 +60,7 @@ def signal_widget(signal, read_only=False):
     if read_only:
         logger.debug("Creating Label for %s", signal.name)
         widget = TyphonLabel
+        name = signal.name + '_label'
     else:
         # Grab a description of the widget to see the correct widget type
         try:
@@ -72,11 +73,15 @@ def signal_widget(signal, read_only=False):
         if 'enum_strs' in desc:
             logger.debug("Creating Combobox for %s", signal.name)
             widget = TyphonComboBox
+            name = signal.name + '_combo'
         # Otherwise a LineEdit will suffice
         else:
             logger.debug("Creating LineEdit for %s", signal.name)
             widget = TyphonLineEdit
-    return widget(init_channel=chan)
+            name = signal.name + '_edit'
+    widget_instance = widget(init_channel=chan)
+    widget_instance.setObjectName(name)
+    return widget_instance
 
 
 class SignalPanel(QGridLayout):

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -16,8 +16,9 @@ import warnings
 from ophyd import Kind, Device
 from ophyd.signal import EpicsSignalBase, EpicsSignalRO
 from ophyd.sim import SignalRO
-from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QApplication, QStyleFactory, QWidget
+from qtpy.QtGui import QColor, QPainter
+from qtpy.QtWidgets import (QApplication, QStyle, QStyleOption, QStyleFactory,
+                            QWidget)
 
 #############
 #  Package  #
@@ -170,6 +171,16 @@ class TyphonBase(QWidget):
         """
         logger.debug("Adding device %s ...", device.name)
         self.devices.append(device)
+
+    def paintEvent(self, event):
+        # This is necessary because by default QWidget ignores stylesheets
+        # https://wiki.qt.io/How_to_Change_the_Background_Color_of_QWidget
+        opt = QStyleOption()
+        opt.initFrom(self)
+        painter = QPainter()
+        painter.begin(self)
+        self.style().drawPrimitive(QStyle.PE_Widget, opt, painter, self)
+        super().paintEvent(event)
 
     @classmethod
     def from_device(cls, device, parent=None, **kwargs):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a few utility properties and names for use with stylesheets:

### TyphonDisplay
Added read-only `pyqtproperty`s `device_name` and `device_class`. This allows you to set a template from a stylesheet like:
```css
TyphonDisplay [device_class='ophyd.sim.SynAxis'] {qproperty-force-template: '/path/to/my/template.ui'}
TyphonDisplay [device_name='test_motor']{...}
TyphonDisplay [device_name='test_motor'][display_type='1']{...}
```
##### Gotchas
* You have to use the integer spec for the `display_type` enum. This could be remedied by adding another property that is the string but I hate the redundancy and an obvious name for the new property escaped me

* The `device_class` is just string matching. No inheritance is respected. Probably not a huge deal but if we start having classes like `AreaDetectorV26` it might get obnoxious 😄 

* If you `force_template` for one of the display types you then need to specify them all. An empty string will use the default (either `happi` or `typhon`). This is because once you set a stylesheet that property is set until overwritten

### TyphonPanel
The `objectName` are set for all of the children widgets inside the layout based on the signal name. This is a nice way to get around the problem where we want units shown for some signals, not for others e.t.c. 

```css
PyDMLineEdit#my_motor_setpoint_edit {qproperty-showUnits: True}
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #141 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests for new properties
<!--
## Screenshots (if appropriate):
-->
