### PR TITLE
Fix Setup and Recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 requirements:
     build:
       - python
+      - setuptools
 
 
     run:

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,10 @@ from setuptools import setup, find_packages
 with open('requirements.txt') as f:
     requirements = f.read().split()
 
-requirements = [r for r in requirements if not r.startswith('git+')]
 git_requirements = [r for r in requirements if r.startswith('git+')]
-print("User must install \n" +
-      "\n".join(f' {r}' for r in git_requirements) +
-      "\n\nmanually")
-
+requirements = [r for r in requirements if not r.startswith('git+')]
+print("User must install the following packages manually:\n" +
+      "\n".join(f' {r}' for r in git_requirements))
 
 setup(name='typhon',
       version=versioneer.get_version(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- `setuptools` is required for package setup
- The message produced in `setup.py` was not correct, this should be remedied now.
