### PR TITLE
Method Button

### DIFF
--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -56,9 +56,8 @@ class MyDevice(Device):
 @pytest.fixture(scope='function')
 def method_button(qtbot):
     dev = MyDevice(name='test')
-    button = TyphonMethodButton()
+    button = TyphonMethodButton.from_device(dev)
     qtbot.addWidget(button)
-    button.add_device(dev)
     button.method_name = 'my_method'
     return button
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -52,3 +52,11 @@ def test_status_thread_completed(qtbot, threaded_status):
     with qtbot.waitSignal(thread.status_finished, timeout=2000):
         status._finished()
     assert listener.finished.called_with(True)
+
+
+def test_status_thread_timeout(threaded_status):
+    listener, thread, status = threaded_status
+    thread.timeout = 0.01
+    thread.run()
+    assert listener.started.called
+    assert not listener.finished.called

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock
+
+from ophyd.status import Status
+import pytest
+from qtpy.QtWidgets import QWidget
+
+from typhon.status import TyphonStatusThread
+
+
+class Listener(QWidget):
+    """Helper to catch signals"""
+    def __init__(self):
+        super().__init__()
+        self.started = Mock()
+        self.finished = Mock()
+
+
+@pytest.fixture(scope='function')
+def threaded_status(qtbot):
+    status = Status()
+    listener = Listener()
+    thread = TyphonStatusThread(status)
+    qtbot.addWidget(listener)
+    thread.status_started.connect(listener.started)
+    thread.status_finished.connect(listener.finished)
+    return listener, thread, status
+
+
+def test_previously_done_status_in_thread(threaded_status):
+    listener, thread, status = threaded_status
+    status._finished()
+    thread.run()
+    assert not listener.started.called
+    assert not listener.finished.called
+
+
+def test_status_finished_during_lag(threaded_status):
+    listener, thread, status = threaded_status
+    thread.lag = 3
+    thread.start()
+    status._finished()
+    thread.wait()
+    assert not listener.started.called
+    assert not listener.finished.called
+
+
+def test_status_thread_completed(qtbot, threaded_status):
+    listener, thread, status = threaded_status
+    with qtbot.waitSignal(thread.status_started, timeout=1000):
+        thread.start()
+    assert listener.started.called
+    with qtbot.waitSignal(thread.status_finished, timeout=2000):
+        status._finished()
+    assert listener.finished.called_with(True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,13 +2,13 @@ import os
 
 from qtpy.QtCore import QRect
 from qtpy.QtGui import QPaintEvent
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QWidget, QMessageBox
 from ophyd import Device, Component as Cpt, Kind
 import pytest
 
 import typhon
 from typhon.utils import (use_stylesheet, clean_name, grab_hints, grab_kind,
-                          TyphonBase)
+                          TyphonBase, raise_to_operator)
 
 class NestedDevice(Device):
     phi = Cpt(Device)
@@ -65,3 +65,16 @@ def test_typhonbase_repaint_smoke():
     tp = TyphonBase()
     pe = QPaintEvent(QRect(1, 2, 3, 4))
     tp.paintEvent(pe)
+
+
+def test_raise_to_operator_msg(monkeypatch):
+
+    monkeypatch.setattr(QMessageBox, 'exec_', lambda x: 1)
+    exc_dialog = None
+    try:
+        1/0
+    except ZeroDivisionError as exc:
+        exc_dialog = raise_to_operator(exc)
+
+    assert exc_dialog is not None
+    assert 'ZeroDivisionError' in exc_dialog.text()

--- a/typhon/designer.py
+++ b/typhon/designer.py
@@ -4,9 +4,10 @@ from pydm.widgets.qtplugin_base import qtplugin_factory
 
 from .signal import TyphonPanel
 from .display import TyphonDisplay
-
+from .func import TyphonMethodButton
 logger = logging.getLogger(__name__)
 
 logging.info("Loading Typhon QtDesigner plugins ...")
 TyphonPanelPlugin = qtplugin_factory(TyphonPanel)
 TyphonDisplayPlugin = qtplugin_factory(TyphonDisplay)
+TyphonMethodButtonPlugin = qtplugin_factory(TyphonMethodButton)

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -306,7 +306,3 @@ class TyphonPanel(TyphonBase, TyphonDesignerMixin, SignalOrder):
     def sizeHint(self):
         """Default SizeHint"""
         return QSize(240, 140)
-
-    def _tx(self, value):
-        """Receive new device information"""
-        self.add_device(value['obj'])

--- a/typhon/status.py
+++ b/typhon/status.py
@@ -1,0 +1,57 @@
+import time
+import logging
+
+from qtpy.QtCore import QThread, Signal
+
+from ophyd.status import wait as status_wait
+
+
+logger = logging.getLogger(__name__)
+
+
+class TyphonStatusThread(QThread):
+    """
+    Parameters
+    ----------
+    delay_draw: float, optional
+        Do not draw anything until a certain amount of time has passed. This
+        avoids rapid flashes for statuses that complete quickly. Units of
+        seconds.
+
+
+    Example
+    ------
+
+    .. code:: python
+
+       status_manager = QtStatusManager()
+       status = motor.set(...)
+       status_manager(status)
+
+    """
+    status_started = Signal()
+    status_finished = Signal(bool)
+
+    def __init__(self, status, lag=0., parent=None):
+        super().__init__(parent=parent)
+        self.status = status
+        self.lag = lag
+
+    def run(self):
+        """Start following a new motion"""
+        # Don't do anything if we are handed a finished status
+        if self.status.done:
+            logger.debug("Status already completed...")
+            return
+        # Wait to draw to avoid too much flashing
+        logger.debug("Waiting for process to last for %r before emitting...",
+                     self.lag)
+        time.sleep(self.lag)
+        if self.status.done:
+            logger.debug("Process was too short to update user interface...")
+            return
+        # Draw
+        self.status_started.emit()
+        status_wait(self.status)
+        logger.debug("Status completed!")
+        self.status_finished.emit(self.status.success)

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -4,10 +4,12 @@ Utility functions for typhon
 ############
 # Standard #
 ############
+import io
 import re
 import logging
 import os.path
 import random
+import traceback
 import warnings
 
 ############
@@ -18,7 +20,7 @@ from ophyd.signal import EpicsSignalBase, EpicsSignalRO
 from ophyd.sim import SignalRO
 from qtpy.QtGui import QColor, QPainter
 from qtpy.QtWidgets import (QApplication, QStyle, QStyleOption, QStyleFactory,
-                            QWidget)
+                            QWidget, QMessageBox)
 
 #############
 #  Package  #
@@ -239,3 +241,18 @@ def clear_layout(layout):
             child.widget().deleteLater()
         elif child.layout():
             clear_layout(child.layout())
+
+
+def raise_to_operator(exc):
+    """Utility function to show an Exception to a user"""
+    logger.error("Reporting error %r to user ...", exc)
+    err_msg = QMessageBox()
+    err_msg.setText(repr(exc))
+    err_msg.setWindowTitle(type(exc).__name__)
+    err_msg.setIcon(QMessageBox.Critical)
+    handle = io.StringIO()
+    traceback.print_tb(exc.__traceback__, file=handle)
+    handle.seek(0)
+    err_msg.setDetailedText(handle.read())
+    err_msg.exec_()
+    return err_msg

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -233,3 +233,8 @@ class TyphonDesignerMixin(PyDMWidget):
             # Connect the channel to the HappiPlugin
             if hasattr(channel, 'connect'):
                 channel.connect()
+
+    @Slot(object)
+    def _tx(self, value):
+        """Receive information from happi channel"""
+        self.add_device(value['obj'])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A button you can drag into `QtDesigner` to run a function. The button accepts an object (either added programmatically or via a `happi` plugin), a `method_name` and whether or not we `use_status` to give the button some state. By default, if `use_status` is `True` we disable the button while the underlying operation is in progress.

In order to show any error messages that may pop up during the execution of the function I made the general `raise_to_operator` method that displays an `Exception` and corresponding `traceback` in an `QMessageBox`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #103 
Closes #126 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Lots of tests. Coverage is going to be low on the `TyphonStatusThread` because it is run mostly inside a `QThread` however all the endpoints are checked in the test suite so it is surely being executed.


## Screenshots (if appropriate):
![button](https://user-images.githubusercontent.com/25753048/50192461-3ddb6480-02e7-11e9-9b45-70cbaaf77f37.gif)

