### PR TITLE
Typhon Command Line Utility

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
 
     run:
       - python
+      - coloredlogs
       - happi
       - numpy
       - ophyd >=1.2.0

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,5 @@
+Command Line Utilities
+======================
+
+.. automodule:: typhon.cli 
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ Related Projects
    :caption: API Documentation
    :hidden:
 
+   cli.rst
    display.rst
    widgets.rst
    plugins.rst

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 git+https://github.com/pcdshub/happi.git
 git+https://github.com/slaclab/pydm.git
 git+https://github.com/pcdshub/QDarkStyleSheet.git
+coloredlogs
 numpy
 qtawesome
 qtconsole

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,4 @@ setup(name='typhon',
       include_package_data=True,
       install_requires=requirements,
       description='Interface generation for ophyd devices',
-      )
+      entry_points= {'console_scripts': ['typhon=typhon.cli:main']})

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,4 @@ setup(name='typhon',
       include_package_data=True,
       install_requires=requirements,
       description='Interface generation for ophyd devices',
-      entry_points= {'console_scripts': ['typhon=typhon.cli:main']})
+      entry_points={'console_scripts': ['typhon=typhon.cli:main']})

--- a/tests/happi.cfg
+++ b/tests/happi.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+path=tests/happi.json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import os
+import pathlib
+
+import pytest
+
+import typhon
+from typhon.cli import typhon_cli, QApplication
+
+
+@pytest.fixture(scope='session')
+def happi_cfg():
+    path = pathlib.Path(__file__)
+    return str(path.parent / 'happi.cfg')
+
+
+def test_cli_version(capsys):
+    typhon_cli(['--version'])
+    readout = capsys.readouterr()
+    assert typhon.__version__ in readout.out
+    assert typhon.__file__ in readout.out
+
+
+def test_cli_happi_cfg(monkeypatch, qtbot, happi_cfg):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    suite = typhon_cli(['test_motor', '--happi-cfg', happi_cfg])
+    qtbot.addWidget(suite)
+    assert 'test_motor' == suite.devices[0].name
+
+
+def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    with open('test.qss', 'w+') as handle:
+        handle.write("TyphonDisplay {qproperty-force_template: 'test.ui'}")
+    style = qapp.styleSheet()
+    suite = typhon_cli(['test_motor', '--stylesheet', 'test.qss',
+                        '--happi-cfg', happi_cfg])
+    qtbot.addWidget(suite)
+    dev_display = suite.get_subdisplay(suite.devices[0])
+    assert dev_display.force_template == 'test.ui'
+    qapp.setStyleSheet(style)
+    os.remove('test.qss')

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,5 +1,6 @@
 import os.path
 
+from pydm.utilities import close_widget_connections
 import pytest
 
 from typhon import TyphonDisplay
@@ -12,7 +13,8 @@ from .conftest import show_widget
 def display(qtbot):
     display = TyphonDisplay()
     qtbot.addWidget(display)
-    return display
+    yield display
+    close_widget_connections(display)
 
 
 @show_widget

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -5,6 +5,7 @@
 ############
 # External #
 ############
+from pydm.utilities import close_widget_connections
 import pytest
 from pyqtgraph.parametertree import ParameterTree, parameterTypes as ptypes
 from qtpy.QtWidgets import QDockWidget
@@ -21,7 +22,8 @@ from .conftest import show_widget
 def suite(qtbot, device):
     suite = TyphonSuite.from_device(device, tools=dict())
     qtbot.addWidget(suite)
-    return suite
+    yield suite
+    close_widget_connections(suite)
 
 
 @show_widget

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -3,7 +3,6 @@ import logging
 import sys
 
 import coloredlogs
-import happi
 from qtpy.QtWidgets import QApplication
 
 import typhon
@@ -48,6 +47,12 @@ def typhon_cli(args):
     # Version endpoint
     if args.version:
         print(f'Typhon: Version {typhon.__version__} from {typhon.__file__}')
+        return
+
+    try:
+        import happi
+    except (ImportError, ModuleNotFoundError):
+        logger.exception("Unable to import happi to load devices!")
         return
 
     logger.debug("Creating Happi Client ...")

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -1,3 +1,4 @@
+"""This module defines the ``typhon`` command line utility"""
 import argparse
 import logging
 import sys
@@ -28,6 +29,10 @@ parser.add_argument('--dark', action='store_true',
                     help='Use the QDarkStyleSheet shipped with typhon')
 parser.add_argument('--stylesheet',
                     help='Additional stylesheet options')
+
+
+# Append to module docs
+__doc__ += '\n::\n\n    ' + parser.format_help().replace('\n', '\n    ')
 
 
 def typhon_cli(args):

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -20,7 +20,7 @@ parser.add_argument('devices', nargs='*',
 parser.add_argument('--happi-cfg',
                     help='Location of happi configuration file '
                          'if not specified by $HAPPI_CFG environment variable')
-parser.add_argument('--version', action='store_true',
+parser.add_argument('--version', '-V', action='store_true',
                     help='Current version and location '
                          'of Typhon installation.')
 parser.add_argument('--debug', action='store_true',

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -23,7 +23,7 @@ parser.add_argument('--happi-cfg',
 parser.add_argument('--version', '-V', action='store_true',
                     help='Current version and location '
                          'of Typhon installation.')
-parser.add_argument('--debug', action='store_true',
+parser.add_argument('--verbose', '-v', action='store_true',
                     help='Show the debug logging stream')
 parser.add_argument('--dark', action='store_true',
                     help='Use the QDarkStyleSheet shipped with typhon')
@@ -39,7 +39,7 @@ def typhon_cli(args):
     args = parser.parse_args(args)
 
     # Logging Level handling
-    if args.debug:
+    if args.verbose:
         level = "DEBUG"
         shown_logger = logging.getLogger('typhon')
     else:

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -1,0 +1,86 @@
+import argparse
+import logging
+import sys
+
+import coloredlogs
+import happi
+from qtpy.QtWidgets import QApplication
+
+import typhon
+
+logger = logging.getLogger(__name__)
+
+# Argument Parser Setup
+parser = argparse.ArgumentParser(description='Create a TyphonSuite for '
+                                             'device/s stored in a Happi '
+                                             'Database')
+
+parser.add_argument('devices', nargs='*',
+                    help='Device names to load in the TyphonSuite')
+parser.add_argument('--happi-cfg',
+                    help='Location of happi configuration file '
+                         'if not specified by $HAPPI_CFG environment variable')
+parser.add_argument('--version', action='store_true',
+                    help='Current version and location '
+                         'of Typhon installation.')
+parser.add_argument('--debug', action='store_true',
+                    help='Show the debug logging stream')
+parser.add_argument('--dark', action='store_true',
+                    help='Use the QDarkStyleSheet shipped with typhon')
+parser.add_argument('--stylesheet',
+                    help='Additional stylesheet options')
+
+
+def typhon_cli(args):
+    args = parser.parse_args(args)
+
+    # Logging Level handling
+    if args.debug:
+        level = "DEBUG"
+        shown_logger = logging.getLogger('typhon')
+    else:
+        shown_logger = logging.getLogger()
+        level = "INFO"
+    coloredlogs.install(level=level, logger=shown_logger,
+                        fmt='[%(asctime)s] - %(levelname)s -  %(message)s')
+    logger.debug("Set logging level of %r to %r", shown_logger.name, level)
+
+    # Version endpoint
+    if args.version:
+        print(f'Typhon: Version {typhon.__version__} from {typhon.__file__}')
+        return
+
+    logger.debug("Creating Happi Client ...")
+    client = happi.Client.from_config(cfg=args.happi_cfg)
+
+    logger.debug("Creating widgets ...")
+    app = QApplication([])
+    suite = typhon.TyphonSuite()
+
+    # Load and add each device
+    for device in args.devices:
+        logger.info("Loading %r ...", device)
+        try:
+            device = client.load_device(name=device)
+            suite.add_device(device)
+            suite.show_subdisplay(device)
+        except Exception:
+            logger.exception("Unable to add %r to TyphonSuite", device)
+
+    # Deal with stylesheet
+    typhon.use_stylesheet(dark=args.dark)
+    if args.stylesheet:
+        logger.info("Loading QSS file %r ...", args.stylesheet)
+        with open(args.stylesheet, 'r') as handle:
+            app.setStyleSheet(handle.read())
+
+    logger.info("Launching application ...")
+    suite.show()
+    app.exec_()
+    logger.info("Execution complete!")
+    return suite
+
+
+def main():
+    """Execute the ``typhon_cli`` with command line arguments"""
+    typhon_cli(sys.argv[1:])

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -65,6 +65,12 @@ def typhon_cli(args):
 
     logger.debug("Creating widgets ...")
     app = QApplication([])
+
+    if args.stylesheet:
+        logger.info("Loading QSS file %r ...", args.stylesheet)
+        with open(args.stylesheet, 'r') as handle:
+            app.setStyleSheet(handle.read())
+
     suite = typhon.TyphonSuite()
 
     # Load and add each device
@@ -79,11 +85,6 @@ def typhon_cli(args):
 
     # Deal with stylesheet
     typhon.use_stylesheet(dark=args.dark)
-    if args.stylesheet:
-        logger.info("Loading QSS file %r ...", args.stylesheet)
-        with open(args.stylesheet, 'r') as handle:
-            app.setStyleSheet(handle.read())
-
     logger.info("Launching application ...")
     suite.show()
     app.exec_()

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -127,6 +127,12 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
         macros: dict, optional
             Macro substitutions to be made in the file
         """
+        # If we are not fully initialized yet do not try and add anything to
+        # the layout. This will happen if the QApplication has a stylesheet
+        # that forces a template, prior to the creation of this display
+        if self.layout() is None:
+            logger.debug("Widget not initialized, do not load template")
+            return
         # Clear anything that exists in the current layout
         if self._main_widget:
             logger.debug("Clearing existing layout ...")

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -170,7 +170,7 @@ class SignalConnection(PyDMConnection):
             for _typ in self.supported_types:
                 try:
                     channel.value_signal[_typ].disconnect(self.put_value)
-                except KeyError:
+                except (KeyError, TypeError):
                     logger.debug("Unable to disconnect value_signal from %s "
                                  "for type %s", channel.address, _typ)
         # Disconnect any other signals


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Typhon command line utility to create a `TyphonSuite` with a group of devices. User passes in a list of devices by name and optionally:
* `--version` just to print information about where the utility comes from
* `--debug` to blast all information from the root logger. Otherwise the `INFO` stream is used from the `typhon` logger
* `--dark` to use `QDarkStyleSheet`
* `--stylesheet` if you want to pass in a custom stylesheet. In my mind this will be for specifying device specific screens e.t.c, not just base widget styling, but the option is there as well.
* `--happi-cfg` if you want to point at a specify `happi` configuration file. Otherwise environment variables are used.

Also saw a few more issues when testing on my fork with freezes on Travis. Explicitly disconnecting a few of my fixtures seemed to help but unsure if this was just a race condition I got lucky on a few times.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #131 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added. By the way this way was way better than just putting a shell script in `bin`. Very simple to test since you can just import it the main function. Just have to be slightly careful about where you actually call the `parse_args`. Certainly going to continue to do it this way in the future.