### PR TITLE
No happi no cry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-git+https://github.com/pcdshub/happi.git
 git+https://github.com/slaclab/pydm.git
 git+https://github.com/pcdshub/QDarkStyleSheet.git
 numpy

--- a/tests/plugins/test_happi.py
+++ b/tests/plugins/test_happi.py
@@ -1,9 +1,13 @@
+import importlib
+import sys
 import types
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from happi import Device
 import pytest
 
+import typhon
+import typhon.plugins
 from typhon.plugins.happi import HappiPlugin, HappiChannel
 
 
@@ -33,3 +37,10 @@ def test_bad_address_smoke(client):
     hp = HappiPlugin()
     hc = HappiChannel(address='happi://not_a_device', tx_slot=lambda x: None)
     hp.add_connection(hc)
+
+
+def test_happi_is_optional():
+    with patch.dict(sys.modules, {'happi': None}):
+        importlib.reload(typhon.plugins)
+        importlib.reload(typhon)
+        assert sys.modules['happi'] is None

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -1,11 +1,17 @@
 __all__ = ['SignalPlugin', 'SignalConnection', 'register_signal',
            'HappiPlugin', 'HappiConnection', 'HappiChannel']
+import logging
 
 from pydm.data_plugins import add_plugin
 
 from .core import SignalPlugin, SignalConnection, register_signal
-from .happi import HappiPlugin, HappiConnection, HappiChannel
 
-# Register custom plugins PyDMApplication
+
+logger = logging.getLogger(__name__)
 add_plugin(SignalPlugin)
-add_plugin(HappiPlugin)
+
+try:
+    from .happi import HappiPlugin, HappiConnection, HappiChannel
+    add_plugin(HappiPlugin)
+except ImportError:
+    logger.warning("Unable to import HappiPlugin")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make `happi` an optional dependency. The only place it was imported before without a `try/except` is in the `HappiPlugin`. This is now protected. In the future we can make a compatibility layer with whatever other device server we happen upon. But until we find a second alternative to `happi` I'm going to hold off.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@tacaswell 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test, largely to protect against regression