### PR TITLE
Plugin and Test Suite Cleanup

### DIFF
--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -23,8 +23,9 @@ def threaded_status(qtbot):
     qtbot.addWidget(listener)
     thread.status_started.connect(listener.started)
     thread.status_finished.connect(listener.finished)
-    return listener, thread, status
-
+    yield listener, thread, status
+    if thread.isRunning():
+        thread.quit()
 
 def test_previously_done_status_in_thread(threaded_status):
     listener, thread, status = threaded_status

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -46,12 +46,10 @@ def test_status_finished_during_lag(threaded_status):
 
 def test_status_thread_completed(qtbot, threaded_status):
     listener, thread, status = threaded_status
-    with qtbot.waitSignal(thread.status_started, timeout=1000):
-        thread.start()
-    assert listener.started.called
-    with qtbot.waitSignal(thread.status_finished, timeout=2000):
-        status._finished()
-    assert listener.finished.called_with(True)
+    thread.start()
+    qtbot.waitUntil(lambda: listener.started.called, timeout=2000)
+    status._finished()
+    qtbot.waitUntil(lambda: listener.finished.called, timeout=2000)
 
 
 def test_status_thread_timeout(threaded_status):

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -157,7 +157,7 @@ class SignalConnection(PyDMConnection):
                     logger.debug("%s has no value_signal for type %s",
                                  channel.address, _typ)
 
-    def remove_listener(self, channel, **kwargs):
+    def remove_listener(self, channel, destroying=False, **kwargs):
         """
         Remove a listener channel from this connection
 
@@ -166,7 +166,7 @@ class SignalConnection(PyDMConnection):
         """
         logger.debug("Removing %r ...", channel)
         # Disconnect put_value from outgoing channel
-        if channel.value_signal is not None:
+        if channel.value_signal is not None and not destroying:
             for _typ in self.supported_types:
                 try:
                     channel.value_signal[_typ].disconnect(self.put_value)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -17,6 +17,7 @@ from qtpy.QtCore import Slot, Qt
 ##########
 # Module #
 ##########
+from ..utils import raise_to_operator
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +88,9 @@ class SignalConnection(PyDMConnection):
                 new_val = self.signal_type(new_val)
             logger.debug("Putting value %r to %r", new_val, self.address)
             self.signal.put(new_val)
-        except Exception:
+        except Exception as exc:
             logger.exception("Unable to put %r to %s", new_val, self.address)
+            raise_to_operator(exc)
 
     def send_new_value(self, value=None, **kwargs):
         """

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -175,6 +175,7 @@ class SignalConnection(PyDMConnection):
                                  "for type %s", channel.address, _typ)
         # Disconnect any other signals
         super().remove_listener(channel, **kwargs)
+        logger.debug("Successfully removed %r", channel)
 
 
 class SignalPlugin(PyDMPlugin):

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -65,10 +65,11 @@ class HappiConnection(PyDMConnection):
         # Send the device and metdata to all of our subscribers
         self.tx.emit({'obj': obj, 'md': md.post()})
 
-    def remove_listener(self, channel, **kwargs):
+    def remove_listener(self, channel, destroying=False, **kwargs):
         """Remove a channel from the database connection"""
         super().remove_listener(channel, **kwargs)
-        self.tx.disconnect(channel.tx_slot)
+        if not destroying:
+            self.tx.disconnect(channel.tx_slot)
 
 
 class HappiPlugin(PyDMPlugin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The test suite is a little unstable and I think may have finally figured out why. In `PyDM v1.6.0` there is now a `destroying` keyword on disconnect which basically lets us know that the `QWidget` which holds the `PyDMChannel` is being garbage collected, not just disconnected. So instead of making sure everything is disconnected on an object that is "between worlds", we just let it pass by. The fundamental reason for this a lot of 💩happens when an `QObject` still has a `Python` representation but doesn't exist in the `C++` layer or vice versa. The `destroying` key was not implemented in either of the `Typhon` plugins which I think is why we were seeing segfaults on fixtures that were continually torn down and re-initialized. 

Secondly, with the `status` tests I was seeing some hangs when running on Travis. This shouldn't really be possible with the `qtbot.waitSignal`, but I have a feeling that the context manager wasn't quite working like it should. I also made sure that any threads started by the fixture are ended before we start our next test. 