### PR TITLE
Fixes to Testing Suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,14 +67,14 @@ before_script:
   - sleep 1
 
 script:
-  - coverage run run_tests.py --disable-warnings 
+  - coverage run run_tests.py
   - coverage report -m
     #- coverage report -m
   - flake8 typhon
   # Test again but with installed version
   - mkdir notest
   - mv typhon/*.* notest
-  - python run_tests.py --disable-warnings
+  - python run_tests.py
   - mv notest/* typhon
   - rmdir notest
   # Build docs

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,6 +1,5 @@
 import os.path
 
-from pydm.utilities import close_widget_connections
 import pytest
 
 from typhon import TyphonDisplay
@@ -13,8 +12,7 @@ from .conftest import show_widget
 def display(qtbot):
     display = TyphonDisplay()
     qtbot.addWidget(display)
-    yield display
-    close_widget_connections(display)
+    return display
 
 
 @show_widget

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -10,7 +10,7 @@ from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
 from ophyd.sim import SynSignal, SynSignalRO
 from ophyd.tests.conftest import using_fake_epics_pv
 from pydm.widgets import PyDMEnumComboBox
-
+from qtpy.QtWidgets import QWidget
 ###########
 # Package #
 ###########
@@ -18,7 +18,7 @@ from typhon.signal import SignalPanel, TyphonPanel
 from .conftest import show_widget, RichSignal, DeadSignal
 
 @using_fake_epics_pv
-def test_panel_creation():
+def test_panel_creation(qtbot):
     panel = SignalPanel(signals={
                     # Signal is its own write
                     'Standard': EpicsSignal('Tst:Pv'),
@@ -30,6 +30,9 @@ def test_panel_creation():
                     # Simulated Signal
                     'Simulated': SynSignal(name='simul'),
                     'SimulatedRO': SynSignalRO(name='simul_ro')})
+    widget = QWidget()
+    qtbot.addWidget(widget)
+    widget.setLayout(panel)
     assert len(panel.signals) == 5
     # Check read-only channels do not have write widgets
     panel.layout().itemAtPosition(2, 1).layout().count() == 1
@@ -42,8 +45,11 @@ def test_panel_creation():
 
 
 @using_fake_epics_pv
-def test_panel_add_enum():
+def test_panel_add_enum(qtbot):
     panel = SignalPanel()
+    widget = QWidget()
+    qtbot.addWidget(widget)
+    widget.setLayout(panel)
     # Create an enum pv
     epics_sig = EpicsSignal("Tst:Enum")
     epics_sig._write_pv.enum_strs = ('A', 'B')
@@ -65,16 +71,22 @@ def test_panel_add_enum():
     return panel
 
 
-def test_add_dead_signal():
+def test_add_dead_signal(qtbot):
     panel = SignalPanel()
+    widget = QWidget()
+    qtbot.addWidget(widget)
+    widget.setLayout(panel)
     dead_sig = DeadSignal(name='ded', value=0)
     panel.add_signal(dead_sig, 'Dead Signal')
     assert 'Dead Signal' in panel.signals
 
 
 @using_fake_epics_pv
-def test_add_pv():
+def test_add_pv(qtbot):
     panel = SignalPanel()
+    widget = QWidget()
+    qtbot.addWidget(widget)
+    widget.setLayout(panel)
     panel.add_pv('Tst:A', 'Read Only')
     assert 'Read Only' in panel.signals
     assert panel.layout().itemAtPosition(0, 1).count() == 1
@@ -83,8 +95,9 @@ def test_add_pv():
 
 
 @show_widget
-def test_typhon_panel(qapp, client):
+def test_typhon_panel(qapp, client, qtbot):
     panel = TyphonPanel()
+    qtbot.addWidget(panel)
     # Setting Kind without device doesn't explode
     panel.showConfig = False
     panel.showConfig = True
@@ -115,8 +128,9 @@ def test_typhon_panel(qapp, client):
 
 
 @show_widget
-def test_typhon_panel_sorting(qapp, client):
+def test_typhon_panel_sorting(qapp, client, qtbot):
     panel = TyphonPanel()
+    qtbot.addWidget(panel)
     # Sort by name
     panel.sortBy = panel.SignalOrder.byName
     panel.channel = 'happi://test_motor'

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import QDockWidget
 ###########
 from typhon.utils import clean_name
 from typhon.suite import TyphonSuite, DeviceParameter
+from typhon.display import TyphonDisplay
 from .conftest import show_widget
 
 
@@ -51,6 +52,9 @@ def test_suite_get_subdisplay_by_device(suite, device):
     display = suite.get_subdisplay(device)
     assert device in display.devices
 
+def test_suite_subdisplay_parentage(suite, device):
+    display = suite.get_subdisplay(device)
+    assert display in suite.findChildren(TyphonDisplay)
 
 def test_suite_get_subdisplay_by_name(suite, device):
     display = suite.get_subdisplay(device.name)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -5,7 +5,6 @@
 ############
 # External #
 ############
-from pydm.utilities import close_widget_connections
 import pytest
 from pyqtgraph.parametertree import ParameterTree, parameterTypes as ptypes
 from qtpy.QtWidgets import QDockWidget
@@ -22,9 +21,7 @@ from .conftest import show_widget
 def suite(qtbot, device):
     suite = TyphonSuite.from_device(device, tools=dict())
     qtbot.addWidget(suite)
-    yield suite
-    close_widget_connections(suite)
-
+    return suite
 
 @show_widget
 def test_suite_with_child_devices(suite, device):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -43,8 +43,9 @@ def test_suite_without_children(device, qtbot):
     assert len(childless_displays) == 0
 
 
-def test_suite_tools(device):
+def test_suite_tools(device, qtbot):
     suite = TyphonSuite.from_device(device)
+    qtbot.addWidget(suite)
     assert len(suite.tools) == 3
     assert len(suite.tools[0].devices) == 1
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,13 +61,14 @@ def test_qtdesigner_env():
     assert 'etc/typhon' in os.getenv('PYQTDESIGNERPATH', '')
 
 
-def test_typhonbase_repaint_smoke():
+def test_typhonbase_repaint_smoke(qtbot):
     tp = TyphonBase()
+    qtbot.addWidget(tp)
     pe = QPaintEvent(QRect(1, 2, 3, 4))
     tp.paintEvent(pe)
 
 
-def test_raise_to_operator_msg(monkeypatch):
+def test_raise_to_operator_msg(monkeypatch, qtbot):
 
     monkeypatch.setattr(QMessageBox, 'exec_', lambda x: 1)
     exc_dialog = None
@@ -76,5 +77,6 @@ def test_raise_to_operator_msg(monkeypatch):
     except ZeroDivisionError as exc:
         exc_dialog = raise_to_operator(exc)
 
+    qtbot.addWidget(exc_dialog)
     assert exc_dialog is not None
     assert 'ZeroDivisionError' in exc_dialog.text()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,9 +2,10 @@ from typhon.widgets import TyphonSidebarItem
 from typhon.suite import SidebarParameter
 
 
-def test_sidebar_item():
+def test_sidebar_item(qtbot):
     param = SidebarParameter(name='test', embeddable=True)
     item = TyphonSidebarItem(param, 0)
+    qtbot.addWidget(item)
     assert len(item.toolbar.actions()) == 3
     assert item.open_action.isEnabled()
     assert item.embed_action.isEnabled()

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -64,7 +64,9 @@ def typhon_cli(args):
     client = happi.Client.from_config(cfg=args.happi_cfg)
 
     logger.debug("Creating widgets ...")
-    app = QApplication([])
+    app = QApplication.instance()
+    if not app:
+        app = QApplication([])
 
     if args.stylesheet:
         logger.info("Loading QSS file %r ...", args.stylesheet)

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -176,7 +176,7 @@ class SignalConnection(PyDMConnection):
                     logger.debug("Unable to disconnect value_signal from %s "
                                  "for type %s", channel.address, _typ)
         # Disconnect any other signals
-        super().remove_listener(channel, **kwargs)
+        super().remove_listener(channel, destroying=destroying, **kwargs)
         logger.debug("Successfully removed %r", channel)
 
 

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -65,8 +65,8 @@ class SignalConnection(PyDMConnection):
         # Collect our signal
         self.signal = signal_registry[address]
         # Subscribe to updates from Ophyd
-        self.signal.subscribe(self.send_new_value,
-                              event_type=self.signal.SUB_VALUE)
+        self._cid = self.signal.subscribe(self.send_new_value,
+                                          event_type=self.signal.SUB_VALUE)
         # Add listener
         self.add_listener(channel)
 
@@ -178,6 +178,10 @@ class SignalConnection(PyDMConnection):
         # Disconnect any other signals
         super().remove_listener(channel, destroying=destroying, **kwargs)
         logger.debug("Successfully removed %r", channel)
+
+    def close(self):
+        """Unsubscribe from the Ophyd signal"""
+        self.signal.unsubscribe(self._cid)
 
 
 class SignalPlugin(PyDMPlugin):

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -67,7 +67,7 @@ class HappiConnection(PyDMConnection):
 
     def remove_listener(self, channel, destroying=False, **kwargs):
         """Remove a channel from the database connection"""
-        super().remove_listener(channel, **kwargs)
+        super().remove_listener(channel, destroying=destroying, **kwargs)
         if not destroying:
             self.tx.disconnect(channel.tx_slot)
 

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -379,6 +379,9 @@ class TyphonSuite(TyphonBase):
             logger.debug("Adding %r to category %r ...",
                          parameter.name(), group.name())
             group.addChild(parameter)
+        # Setup window to have a parent
+        parameter.value().setParent(self)
+        parameter.value().setHidden(True)
         logger.debug("Connecting parameter signals ...")
         parameter.sigOpen.connect(partial(self.show_subdisplay,
                                           parameter))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Thank you @hhslepicka @klauer! I think everything should be far more stable. Issues resolved in this PR:
1. Creating another `QApplication` is bad. I thought this exploded on sight but it doesn't, in fact sometimes the test suite passed. No idea, but removing this mistake seemed to stop the major problems seen locally.
2. In `TyphonSuite` I was creating widgets then not setting their parents. This never caused a problem in actual use, but when I thought `qtbot.addWidget` would clean these up, they would not get found because they were children of the `QApplication` itself. I think this caused some of the sporadic freezes seen before. I now explicitly call `setParent` on these so they will be captured by anything that affects the children of `TyphonSuite`
3. There were a few tests I was sloppy with adding widgets to `qtbot`.
4. `destroying` was not being passed to the `super().remove_connection` call
5. When `SignalConnection` is closed (i. e the `Signal` has no more listeners), we should `unsubscribe` ourselves from any changes in the `Signal`.