### PR TITLE
Positioner

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,3 +51,4 @@ Related Projects
    display.rst
    widgets.rst
    plugins.rst
+   positioner.rst

--- a/docs/source/positioner.rst
+++ b/docs/source/positioner.rst
@@ -1,0 +1,5 @@
+TyphonPositionerWidget
+======================
+
+.. autoclass:: typhon.TyphonPositionerWidget
+   :members:

--- a/run_tests.py
+++ b/run_tests.py
@@ -18,8 +18,8 @@ if __name__ == '__main__':
 
     print('pytest arguments: {}'.format(args))
 
-    root_logger = logging.getLogger('typhon')
-    root_logger.setLevel(logging.DEBUG)
+    typhon_logger = logging.getLogger('typhon')
+    pydm_logger = logging.getLogger('pydm')
     log_dir = Path(os.path.dirname(__file__)) / 'logs'
     log_file = log_dir / 'run_tests_log.txt'
 
@@ -35,14 +35,14 @@ if __name__ == '__main__':
     if do_rollover:
         handler.doRollover()
     formatter = logging.Formatter(fmt=('%(asctime)s.%(msecs)03d '
-                                       '%(module)-13s '
+                                       '%(name)-30s '
                                        '%(levelname)-8s '
                                        '%(threadName)-10s '
                                        '%(message)s'),
                                   datefmt='%H:%M:%S')
     handler.setFormatter(formatter)
-    root_logger.addHandler(handler)
-
-    logger = logging.getLogger(__name__)
+    for log in (typhon_logger, pydm_logger):
+        log.setLevel(logging.DEBUG)
+        log.addHandler(handler)
 
     sys.exit(pytest.main(args))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,6 @@ def show_widget(func):
         if show_widgets:
             # Display the widget
             widget.show()
-            application.establish_widget_connections(widget)
             # Start the application
             application.exec_()
     return func_wrapper

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -49,8 +49,8 @@ def test_positioner_widget_with_signal_limits(motor_widget):
     # Check limit switches
     low_limit_chan = widget.ui.low_limit_switch.channel
     assert motor.low_limit_switch.name in low_limit_chan
-    low_limit_chan = widget.ui.low_limit_switch.channel
-    assert motor.low_limit_switch.name in low_limit_chan
+    high_limit_chan = widget.ui.high_limit_switch.channel
+    assert motor.high_limit_switch.name in high_limit_chan
     motor.delay = 3.  # Just for visual testing purposes
     return widget
 

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -51,6 +51,7 @@ def test_positioner_widget_with_signal_limits(motor_widget):
     assert motor.low_limit_switch.name in low_limit_chan
     low_limit_chan = widget.ui.low_limit_switch.channel
     assert motor.low_limit_switch.name in low_limit_chan
+    motor.delay = 3.  # Just for visual testing purposes
     return widget
 
 

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+
+import pytest
+from ophyd import Component as Cpt, Signal
+from ophyd.sim import SynAxis, SignalRO
+
+from typhon.positioner import TyphonPositionerWidget
+
+from .conftest import show_widget
+
+
+class SimMotor(SynAxis):
+    low_limit_switch = Cpt(SignalRO, value=0)
+    high_limit_switch = Cpt(SignalRO, value=0)
+    low_limit = Cpt(Signal, value=-10)
+    high_limit = Cpt(Signal, value=10)
+    stop = Mock()
+
+
+@pytest.fixture(scope='function')
+def motor_widget(qtbot):
+    motor = SimMotor(name='test')
+    setwidget = TyphonPositionerWidget.from_device(motor)
+    qtbot.addWidget(setwidget)
+    return motor, setwidget
+
+
+def test_positioner_widget_no_limits(qtbot, motor):
+    setwidget = TyphonPositionerWidget.from_device(motor)
+    qtbot.addWidget(setwidget)
+    for widget in ('low_limit', 'low_limit_switch',
+                   'high_limit', 'high_limit_switch'):
+        assert getattr(setwidget.ui, widget).isHidden()
+
+
+def test_positioner_widget_fixed_limits(qtbot, motor):
+    motor.limits = (-10, 10)
+    widget = TyphonPositionerWidget.from_device(motor)
+    qtbot.addWidget(widget)
+    assert widget.ui.low_limit.text() == '-10'
+    assert widget.ui.high_limit.text() == '10'
+
+
+@show_widget
+def test_positioner_widget_with_signal_limits(motor_widget):
+    motor, widget = motor_widget
+    # Check limit switches
+    low_limit_chan = widget.ui.low_limit_switch.channel
+    assert motor.low_limit_switch.name in low_limit_chan
+    low_limit_chan = widget.ui.low_limit_switch.channel
+    assert motor.low_limit_switch.name in low_limit_chan
+    return widget
+
+
+def test_positioner_widget_readback(motor_widget):
+    motor, widget = motor_widget
+    assert motor.readback.name in widget.ui.user_readback.channel
+
+
+def test_positioner_widget_stop(motor_widget):
+    motor, widget = motor_widget
+    widget.stop()
+    assert motor.stop.called
+
+
+def test_positioner_widget_set(motor_widget):
+    motor, widget = motor_widget
+    # Check motion
+    widget.ui.set_value.setText('4')
+    widget.ui.set()
+    assert motor.position == 4
+
+
+def test_positioner_widget_positive_tweak(motor_widget):
+    motor, widget = motor_widget
+    widget.ui.tweak_value.setText('1')
+    widget.positive_tweak()
+    assert motor.position == 1
+
+
+def test_positioner_widget_negative_tweak(motor_widget):
+    motor, widget = motor_widget
+    widget.ui.tweak_value.setText('1')
+    widget.negative_tweak()
+    assert motor.position == -1

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -96,3 +96,15 @@ def test_positioner_widget_moving_property(motor_widget, qtbot):
     widget.set()
     qtbot.waitUntil(lambda: widget.moving, timeout=500)
     qtbot.waitUntil(lambda: not widget.moving, timeout=1000)
+
+
+def test_positioner_widget_last_move(motor_widget, qtbot):
+    motor, widget = motor_widget
+    assert not widget.successful_move
+    assert not widget.failed_move
+    widget.done_moving(True)
+    assert widget.successful_move
+    assert not widget.failed_move
+    widget.done_moving(False)
+    assert not widget.successful_move
+    assert widget.failed_move

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -78,6 +78,7 @@ def test_positioner_widget_positive_tweak(motor_widget):
     motor, widget = motor_widget
     widget.ui.tweak_value.setText('1')
     widget.positive_tweak()
+    assert widget.ui.set_value.text() == '1.0'
     assert motor.position == 1
 
 
@@ -85,6 +86,7 @@ def test_positioner_widget_negative_tweak(motor_widget):
     motor, widget = motor_widget
     widget.ui.tweak_value.setText('1')
     widget.negative_tweak()
+    assert widget.ui.set_value.text() == '-1.0'
     assert motor.position == -1
 
 

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,7 +1,10 @@
 __all__ = ['TyphonDisplay', 'DeviceDisplay', 'use_stylesheet',
-           'register_signal', 'TyphonSuite']
+           'register_signal', 'TyphonSuite', 'TyphonPanel',
+           'TyphonPositionerWidget']
 from .display import TyphonDisplay, DeviceDisplay
 from .suite import TyphonSuite
+from .signal import TyphonPanel
+from .positioner import TyphonPositionerWidget
 from .utils import use_stylesheet
 from .plugins import register_signal
 from ._version import get_versions

--- a/typhon/designer.py
+++ b/typhon/designer.py
@@ -5,9 +5,12 @@ from pydm.widgets.qtplugin_base import qtplugin_factory
 from .signal import TyphonPanel
 from .display import TyphonDisplay
 from .func import TyphonMethodButton
+from .positioner import TyphonPositionerWidget
+
 logger = logging.getLogger(__name__)
 
 logging.info("Loading Typhon QtDesigner plugins ...")
 TyphonPanelPlugin = qtplugin_factory(TyphonPanel)
 TyphonDisplayPlugin = qtplugin_factory(TyphonDisplay)
 TyphonMethodButtonPlugin = qtplugin_factory(TyphonMethodButton)
+TyphonPositionerWidgetPlugin = qtplugin_factory(TyphonPositionerWidget)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -6,7 +6,8 @@ from pydm import Display
 from qtpy.QtCore import Property, Slot, Q_ENUMS
 from qtpy.QtWidgets import QHBoxLayout, QWidget
 
-from .utils import ui_dir, TyphonBase, clear_layout
+from .utils import (ui_dir, TyphonBase, clear_layout,
+                    reload_widget_stylesheet)
 from .widgets import TyphonDesignerMixin
 
 
@@ -159,10 +160,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
             self._main_widget = QWidget()
         finally:
             self.layout().addWidget(self._main_widget)
-            # The following code reapplies the stylesheet
-            self.style().unpolish(self)
-            self.style().polish(self)
-            self.update()
+            reload_widget_stylesheet(self)
 
     @Property(str)
     def force_template(self):

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -103,7 +103,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     @Property(str, designable=False)
     def device_class(self):
         """Full class with module name of loaded device"""
-        if self.devices:
+        if getattr(self, 'devices', []):
             device_class = self.devices[0].__class__
             return '.'.join((device_class.__module__,
                              device_class.__name__))
@@ -112,7 +112,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     @Property(str, designable=False)
     def device_name(self):
         "Name of loaded device"
-        if self.devices:
+        if getattr(self, 'devices', []):
             return self.devices[0].name
         return ''
 

--- a/typhon/func.py
+++ b/typhon/func.py
@@ -440,9 +440,9 @@ class TyphonMethodButton(QPushButton, TyphonDesignerMixin):
     _max_allowed_operation = 10.0
 
     def __init__(self, parent=None):
-        super().__init__(parent=parent)
         self._method = ''
         self._use_status = False
+        super().__init__(parent=parent)
         self._status_thread = None
         self.clicked.connect(self.execute)
         self.devices = list()

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -157,7 +157,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
         Current state of widget
 
         This will lag behind the actual state of the positioner in order to
-        prevent unneccesary rapid movements
+        prevent unnecessary rapid movements
         """
         return getattr(self, '_moving', False)
 

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -21,7 +21,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
 
     Standard positioner motion requires a large amount of context for operators.
     For most motors, it may not be enough to simply have a text field where
-    method can be punched in. Instead, information like soft limits and
+    setpoints can be punched in. Instead, information like soft limits and
     hardware limit switches are crucial for a full understanding of the
     position and behavior of a motor. This widget can supply a standard display
     for all of these, but at a bare minimum the provided ``Device`` needs a

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -1,0 +1,130 @@
+import os.path
+import logging
+
+from ophyd import Device
+from qtpy import uic
+from qtpy.QtCore import Slot
+
+from .plugins import register_signal
+from .utils import (TyphonBase, ui_dir, channel_from_signal, grab_kind,
+                    raise_to_operator)
+from .widgets import TyphonDesignerMixin
+
+
+logger = logging.getLogger(__name__)
+
+
+class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
+    """
+    Widget to interact with an ``ophyd.Positioner``
+
+    Standard positioner motion requires a large amount of context for operator.
+    For most motors, in may not be enough to simply have a text field where
+    method can be punched in. Instead, information like soft limits and
+    hardware limit switches are crucial for a full understanding of the
+    position and behavior of a motor. This widget can supply a standard display
+    for all of these, but at a bare minimum the provided ``Device`` needs a
+    valid ``set`` function. The rest of the signals are searched for assuming
+    that the interface matches the ``EpicsMotor`` example supplied in
+    ``ophyd``.
+    """
+    ui_template = os.path.join(ui_dir, 'positioner.ui')
+
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        # Instantiate UI
+        self.ui = uic.loadUi(self.ui_template, self)
+        self.ui.progress_bar.hide()  # Hide until we are ready to move
+        # Connect signals to slots
+        self.ui.set_value.returnPressed.connect(self.set)
+        self.ui.tweak_positive.clicked.connect(self.positive_tweak)
+        self.ui.tweak_negative.clicked.connect(self.negative_tweak)
+        self.ui.stop_button.clicked.connect(self.stop)
+        self._readback = None
+
+    @Slot()
+    def set(self):
+        """Set the device to the value configured by ``ui.set_value``"""
+        self._set(float(self.ui.set_value.text()))
+
+    @Slot()
+    def positive_tweak(self):
+        """Tweak positive by the amount listed in ``ui.tweak_value``"""
+        setpoint = self._get_position() + float(self.tweak_value.text())
+        self._set(setpoint)
+
+    @Slot()
+    def negative_tweak(self):
+        """Tweak negative by the amount listed in ``ui.tweak_value``"""
+        setpoint = self._get_position() - float(self.tweak_value.text())
+        self._set(setpoint)
+
+    @Slot()
+    def stop(self):
+        """Stop device"""
+        for device in self.devices:
+            device.stop()
+
+    def _get_position(self):
+        if not self._readback:
+            raise Exception("No Device configured for widget!")
+        return self._readback.get()
+
+    def _set(self, value):
+        try:
+            if not self.devices:
+                raise Exception("No Device configured for widget!")
+            self.devices[0].set(value)
+        except Exception as exc:
+            logger.exception("Error setting %r to %r",
+                             self.devices[0], value)
+            raise_to_operator(exc)
+
+    def add_device(self, device):
+        """Add a device to the widget"""
+        # Add device to cache
+        self.devices.clear()  # only one device allowed
+        super().add_device(device)
+        # Limit switches
+        for limit_switch in ('low_limit_switch',
+                             'high_limit_switch'):
+            # If our device has a limit switch attach it
+            if getattr(device, limit_switch, False):
+                widget = getattr(self.ui, limit_switch)
+                limit = getattr(device, limit_switch)
+                limit_chan = channel_from_signal(limit)
+                register_signal(limit)
+                widget.channel = limit_chan
+            # Otherwise, hide it the widget
+            else:
+                getattr(self.ui, limit_switch).hide()
+        # User Readback
+        if hasattr(device, 'user_readback'):
+            self._readback = device.user_readback
+        else:
+            # Let us assume it is the first hint
+            self._readback = grab_kind(device, 'hinted')[0][1]
+        register_signal(self._readback)
+        self.ui.user_readback.channel = channel_from_signal(self._readback)
+        # Limit values
+        # Look for limit signals first
+        if isinstance(device, Device):
+            limit_signals = ('low_limit' in device.component_names
+                             and 'high_limit' in device.component_names)
+            # Use raw signals to keep widget updated
+            if limit_signals:
+                register_signal(device.low_limit)
+                low_lim_chan = channel_from_signal(device.low_limit)
+                self.ui.low_limit.channel = low_lim_chan
+                register_signal(device.high_limit)
+                high_lim_chan = channel_from_signal(device.high_limit)
+                self.ui.high_limit.channel = high_lim_chan
+                return
+        # Check that we have limits at all, or if they are implemented
+        if hasattr(device, 'limits') and device.limits[0] != device.limits[1]:
+            self.ui.low_limit.setText(str(device.limits[0]))
+            self.ui.high_limit.setText(str(device.limits[1]))
+        # Look for limit value components
+        else:
+            self.ui.low_limit.hide()
+            self.ui.high_limit.hide()

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -49,32 +49,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
     @Slot()
     def set(self):
         """Set the device to the value configured by ``ui.set_value``"""
-        self._set(self.ui.set_value.text())
-
-    @Slot()
-    def positive_tweak(self):
-        """Tweak positive by the amount listed in ``ui.tweak_value``"""
-        setpoint = self._get_position() + float(self.tweak_value.text())
-        self._set(setpoint)
-
-    @Slot()
-    def negative_tweak(self):
-        """Tweak negative by the amount listed in ``ui.tweak_value``"""
-        setpoint = self._get_position() - float(self.tweak_value.text())
-        self._set(setpoint)
-
-    @Slot()
-    def stop(self):
-        """Stop device"""
-        for device in self.devices:
-            device.stop()
-
-    def _get_position(self):
-        if not self._readback:
-            raise Exception("No Device configured for widget!")
-        return self._readback.get()
-
-    def _set(self, value):
+        value = self.ui.set_value.text()
         try:
             # Check that we have a device configured
             if not self.devices:
@@ -101,6 +76,31 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
             self._last_move = False
             reload_widget_stylesheet(self, cascade=True)
             raise_to_operator(exc)
+
+    @Slot()
+    def positive_tweak(self):
+        """Tweak positive by the amount listed in ``ui.tweak_value``"""
+        setpoint = self._get_position() + float(self.tweak_value.text())
+        self.ui.set_value.setText(str(setpoint))
+        self.set()
+
+    @Slot()
+    def negative_tweak(self):
+        """Tweak negative by the amount listed in ``ui.tweak_value``"""
+        setpoint = self._get_position() - float(self.tweak_value.text())
+        self.ui.set_value.setText(str(setpoint))
+        self.set()
+
+    @Slot()
+    def stop(self):
+        """Stop device"""
+        for device in self.devices:
+            device.stop()
+
+    def _get_position(self):
+        if not self._readback:
+            raise Exception("No Device configured for widget!")
+        return self._readback.get()
 
     def add_device(self, device):
         """Add a device to the widget"""

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -50,7 +50,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
     @Slot()
     def set(self):
         """Set the device to the value configured by ``ui.set_value``"""
-        self._set(float(self.ui.set_value.text()))
+        self._set(self.ui.set_value.text())
 
     @Slot()
     def positive_tweak(self):
@@ -88,7 +88,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
             self._last_move = None
             # Call the set
             logger.debug("Setting device %r to %r", self.devices[0], value)
-            status = self.devices[0].set(value)
+            status = self.devices[0].set(float(value))
             logger.debug("Setting up new status thread ...")
             self._status_thread = TyphonStatusThread(
                                         status,

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -161,7 +161,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
         This will lag behind the actual state of the positioner in order to
         prevent unneccesary rapid movements
         """
-        return self._moving
+        return getattr(self, '_moving', False)
 
     @moving.setter
     def moving(self, value):

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -38,7 +38,6 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
         super().__init__(parent=parent)
         # Instantiate UI
         self.ui = uic.loadUi(self.ui_template, self)
-        self.ui.progress_bar.hide()  # Hide until we are ready to move
         # Connect signals to slots
         self.ui.set_value.returnPressed.connect(self.set)
         self.ui.tweak_positive.clicked.connect(self.positive_tweak)

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -143,7 +143,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
                 self.ui.high_limit.channel = high_lim_chan
                 return
         # Check that we have limits at all, or if they are implemented
-        if hasattr(device, 'limits') and device.limits[0] != device.limits[1]:
+        if hasattr(device, 'limits') and device.limits[0] < device.limits[1]:
             self.ui.low_limit.setText(str(device.limits[0]))
             self.ui.high_limit.setText(str(device.limits[1]))
         # Look for limit value components

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -77,7 +77,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
             self.devices[0].set(value)
         except Exception as exc:
             logger.exception("Error setting %r to %r",
-                             self.devices[0], value)
+                             self.devices, value)
             raise_to_operator(exc)
 
     def add_device(self, device):

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -19,7 +19,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
     """
     Widget to interact with an ``ophyd.Positioner``
 
-    Standard positioner motion requires a large amount of context for operator.
+    Standard positioner motion requires a large amount of context for operators.
     For most motors, in may not be enough to simply have a text field where
     method can be punched in. Instead, information like soft limits and
     hardware limit switches are crucial for a full understanding of the

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -1,4 +1,3 @@
-from functools import partial
 import os.path
 import logging
 
@@ -95,10 +94,6 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
                                         lag=self._min_visible_operation)
             self._status_thread.status_started.connect(self.move_changed)
             self._status_thread.status_finished.connect(self.done_moving)
-            # In case something kills our status_thread make sure we cleanup
-            # properly
-            self._status_thread.finished.connect(partial(self.done_moving,
-                                                         False))
             self._status_thread.start()
         except Exception as exc:
             logger.exception("Error setting %r to %r",

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -20,14 +20,34 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
     Widget to interact with an ``ophyd.Positioner``
 
     Standard positioner motion requires a large amount of context for
-    operators.For most motors, it may not be enough to simply have a text field
-    where setpoints can be punched in. Instead, information like soft limits
-    and hardware limit switches are crucial for a full understanding of the
-    position and behavior of a motor. This widget can supply a standard display
-    for all of these, but at a bare minimum the provided ``Device`` needs a
-    valid ``set`` function. The rest of the signals are searched for assuming
-    that the interface matches the ``EpicsMotor`` example supplied in
-    ``ophyd``.
+    operators. For most motors, it may not be enough to simply have a text
+    field where setpoints can be punched in. Instead, information like soft
+    limits and hardware limit switches are crucial for a full understanding of
+    the position and behavior of a motor. The widget will work with any object
+    that implements ``set``, however to get other relevant information, we also
+    duck-type to see if we can find other useful signals.  Below is a table of
+    attributes that the widget looks for to inform screen design:
+
+    ============== ===========================================================
+    Widget         Attribute Selection
+    ============== ===========================================================
+    User Readback  The widget first searches for a ``Signal`` called
+                   ``user_readback``. If this is not found the
+                   **first** hint is used.
+
+    Limit Switches Attributes ``low_limit_switch`` and ``high_limit_switch``
+                   are queried. If these are not found the widgets are hidden.
+
+    Soft Limits    The widget first looks for ``low_limit`` and ``high_limit``
+                   signals. If these do not exist, we look for ``limits`` and
+                   sets the text to match the returned tuple from this method.
+
+    Set and Tweak  Both of these methods simply use ``Device.set`` which is
+                   expected to take a ``float`` and return a ``status`` object
+                   that indicates the motion completeness. Must be implemented.
+
+    Stop           Device.stop()
+    ============== ===========================================================
     """
     ui_template = os.path.join(ui_dir, 'positioner.ui')
     _min_visible_operation = 0.1

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -20,7 +20,7 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
     Widget to interact with an ``ophyd.Positioner``
 
     Standard positioner motion requires a large amount of context for operators.
-    For most motors, in may not be enough to simply have a text field where
+    For most motors, it may not be enough to simply have a text field where
     method can be punched in. Instead, information like soft limits and
     hardware limit switches are crucial for a full understanding of the
     position and behavior of a motor. This widget can supply a standard display

--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -19,10 +19,10 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
     """
     Widget to interact with an ``ophyd.Positioner``
 
-    Standard positioner motion requires a large amount of context for operators.
-    For most motors, it may not be enough to simply have a text field where
-    setpoints can be punched in. Instead, information like soft limits and
-    hardware limit switches are crucial for a full understanding of the
+    Standard positioner motion requires a large amount of context for
+    operators.For most motors, it may not be enough to simply have a text field
+    where setpoints can be punched in. Instead, information like soft limits
+    and hardware limit switches are crucial for a full understanding of the
     position and behavior of a motor. This widget can supply a standard display
     for all of these, but at a bare minimum the provided ``Device`` needs a
     valid ``set`` function. The rest of the signals are searched for assuming

--- a/typhon/ui/detailed_positioner.ui
+++ b/typhon/ui/detailed_positioner.ui
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>320</width>
+    <height>455</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,3">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="name_label">
+     <property name="font">
+      <font>
+       <family>Sans Serif</family>
+       <pointsize>20</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>${name}</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="underline">
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphonPositionerWidget" name="TyphonPositionerWidget">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="signal_tab">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::North</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabsClosable">
+      <bool>false</bool>
+     </property>
+     <property name="movable">
+      <bool>false</bool>
+     </property>
+     <property name="tabBarAutoHide">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="normal_tab">
+      <attribute name="title">
+       <string>Normal</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="normal_scroll">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="normal_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>298</width>
+            <height>222</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphonPanel" name="normal_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="showConfig" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="config_tab">
+      <attribute name="title">
+       <string>Configuration</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="config_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="config_scroll">
+         <property name="font">
+          <font>
+           <underline>false</underline>
+          </font>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="config_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>298</width>
+            <height>222</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphonPanel" name="config_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="misc_tab">
+      <attribute name="title">
+       <string>Miscellaneous</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="misc_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="misc_scroll">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="misc_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>298</width>
+            <height>222</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphonPanel" name="misc_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showConfig" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphonPanel</class>
+   <extends>QWidget</extends>
+   <header>typhon.signal</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphonPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhon.positioner</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhon/ui/embedded_positioner.ui
+++ b/typhon/ui/embedded_positioner.ui
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>303</width>
+    <height>194</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>600</width>
+    <height>300</height>
+   </size>
+  </property>
+  <property name="sizeIncrement">
+   <size>
+    <width>1</width>
+    <height>1</height>
+   </size>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>400</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,2">
+   <property name="spacing">
+    <number>3</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="button_layout" stretch="1,0">
+     <property name="spacing">
+      <number>2</number>
+     </property>
+     <property name="leftMargin">
+      <number>10</number>
+     </property>
+     <property name="topMargin">
+      <number>2</number>
+     </property>
+     <property name="rightMargin">
+      <number>2</number>
+     </property>
+     <property name="bottomMargin">
+      <number>2</number>
+     </property>
+     <item alignment="Qt::AlignLeft">
+      <widget class="QLabel" name="name_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <family>Sans Serif</family>
+         <pointsize>20</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+         <kerning>true</kerning>
+        </font>
+       </property>
+       <property name="text">
+        <string>${name}</string>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QFrame" name="underline">
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphonPositionerWidget" name="TyphonPositionerWidget">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphonPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhon.positioner</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhon/ui/positioner.ui
+++ b/typhon/ui/positioner.ui
@@ -1,0 +1,421 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>299</width>
+    <height>167</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="set_layout" stretch="0,0,0">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <item>
+      <layout class="QVBoxLayout" name="low_limit_layout" stretch="0,0,1">
+       <property name="spacing">
+        <number>5</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <item alignment="Qt::AlignHCenter">
+        <widget class="PyDMByteIndicator" name="low_limit_switch">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>25</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    Widget for graphical representation of bits from an integer number
+    with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+         </property>
+         <property name="onColor" stdset="0">
+          <color>
+           <red>239</red>
+           <green>246</green>
+           <blue>20</blue>
+          </color>
+         </property>
+         <property name="offColor" stdset="0">
+          <color>
+           <red>178</red>
+           <green>188</green>
+           <blue>17</blue>
+          </color>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMLabel" name="low_limit">
+         <property name="font">
+          <font>
+           <pointsize>-1</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">font-size: 8px; background-color: None; color: None;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="value_layout" stretch="0,1,1,1,0">
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <item>
+        <widget class="QProgressBar" name="progress_bar">
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="maximum">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>4</number>
+         </property>
+         <property name="textVisible">
+          <bool>true</bool>
+         </property>
+         <property name="textDirection">
+          <enum>QProgressBar::TopToBottom</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMLabel" name="user_readback">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="set_value">
+         <property name="minimumSize">
+          <size>
+           <width>20</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="tweak_layout" stretch="0,1,0">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QToolButton" name="tweak_negative">
+           <property name="minimumSize">
+            <size>
+             <width>25</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>-</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="tweak_value">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="tweak_positive">
+           <property name="minimumSize">
+            <size>
+             <width>25</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>+</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QPushButton" name="stop_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>175</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
+         </property>
+         <property name="text">
+          <string>Stop</string>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
+         <property name="default">
+          <bool>false</bool>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="high_limit_layout" stretch="0,0,1">
+       <property name="spacing">
+        <number>5</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <item alignment="Qt::AlignHCenter">
+        <widget class="PyDMByteIndicator" name="high_limit_switch">
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    Widget for graphical representation of bits from an integer number
+    with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">margin: 0px;</string>
+         </property>
+         <property name="onColor" stdset="0">
+          <color>
+           <red>239</red>
+           <green>246</green>
+           <blue>20</blue>
+          </color>
+         </property>
+         <property name="offColor" stdset="0">
+          <color>
+           <red>178</red>
+           <green>188</green>
+           <blue>17</blue>
+          </color>
+         </property>
+         <property name="orientation" stdset="0">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="showLabels" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="circles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="shift" stdset="0">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="PyDMLabel" name="high_limit">
+         <property name="font">
+          <font>
+           <pointsize>-1</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">font-size: 8px; background-color: None; color: None;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhon/ui/positioner.ui
+++ b/typhon/ui/positioner.ui
@@ -113,14 +113,14 @@
         <widget class="PyDMLabel" name="low_limit">
          <property name="font">
           <font>
-           <pointsize>-1</pointsize>
+           <pointsize>8</pointsize>
           </font>
          </property>
          <property name="toolTip">
           <string/>
          </property>
          <property name="styleSheet">
-          <string notr="true">font-size: 8px; background-color: None; color: None;</string>
+          <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -371,14 +371,14 @@
         <widget class="PyDMLabel" name="high_limit">
          <property name="font">
           <font>
-           <pointsize>-1</pointsize>
+           <pointsize>8</pointsize>
           </font>
          </property>
          <property name="toolTip">
           <string/>
          </property>
          <property name="styleSheet">
-          <string notr="true">font-size: 8px; background-color: None; color: None;</string>
+          <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>

--- a/typhon/ui/positioner.ui
+++ b/typhon/ui/positioner.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>299</width>
-    <height>141</height>
+    <width>325</width>
+    <height>167</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -19,7 +19,10 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1">
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0">
    <property name="spacing">
     <number>10</number>
    </property>
@@ -36,46 +39,53 @@
     <number>5</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="set_layout" stretch="0,0,0">
-     <property name="spacing">
-      <number>5</number>
+    <widget class="QFrame" name="motion_frame">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
      </property>
-     <item>
-      <layout class="QVBoxLayout" name="low_limit_layout" stretch="0,0,1">
-       <property name="spacing">
-        <number>5</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <item alignment="Qt::AlignHCenter">
-        <widget class="PyDMByteIndicator" name="low_limit_switch">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>25</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>25</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <layout class="QHBoxLayout" name="set_layout" stretch="0,0,0">
+      <property name="spacing">
+       <number>5</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="low_limit_layout" stretch="0,0,1">
+        <property name="spacing">
+         <number>5</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <item alignment="Qt::AlignHCenter">
+         <widget class="PyDMByteIndicator" name="low_limit_switch">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>25</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="whatsThis">
+           <string>
     Widget for graphical representation of bits from an integer number
     with support for Channels and more from PyDM
 
@@ -86,226 +96,226 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
-         </property>
-         <property name="onColor" stdset="0">
-          <color>
-           <red>239</red>
-           <green>246</green>
-           <blue>20</blue>
-          </color>
-         </property>
-         <property name="offColor" stdset="0">
-          <color>
-           <red>178</red>
-           <green>188</green>
-           <blue>17</blue>
-          </color>
-         </property>
-         <property name="showLabels" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="circles" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMLabel" name="low_limit">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="value_layout" stretch="1,1,1,0">
-       <property name="spacing">
-        <number>10</number>
-       </property>
-       <item>
-        <widget class="PyDMLabel" name="user_readback">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string/>
-         </property>
-         <property name="styleSheet">
-          <string notr="true"/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="set_value">
-         <property name="minimumSize">
-          <size>
-           <width>20</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="styleSheet">
-          <string notr="true"/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="tweak_layout" stretch="0,1,0">
-         <property name="spacing">
-          <number>3</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QToolButton" name="tweak_negative">
-           <property name="minimumSize">
-            <size>
-             <width>25</width>
-             <height>25</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>-</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="tweak_value">
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>25</height>
-            </size>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="tweak_positive">
-           <property name="minimumSize">
-            <size>
-             <width>25</width>
-             <height>25</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>+</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QPushButton" name="stop_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>175</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
-         </property>
-         <property name="text">
-          <string>Stop</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-         <property name="default">
-          <bool>false</bool>
-         </property>
-         <property name="flat">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="high_limit_layout" stretch="0,0,1">
-       <property name="spacing">
-        <number>5</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <item alignment="Qt::AlignHCenter">
-        <widget class="PyDMByteIndicator" name="high_limit_switch">
-         <property name="minimumSize">
-          <size>
-           <width>25</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string>
+          </property>
+          <property name="onColor" stdset="0">
+           <color>
+            <red>239</red>
+            <green>246</green>
+            <blue>20</blue>
+           </color>
+          </property>
+          <property name="offColor" stdset="0">
+           <color>
+            <red>178</red>
+            <green>188</green>
+            <blue>17</blue>
+           </color>
+          </property>
+          <property name="showLabels" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="circles" stdset="0">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="PyDMLabel" name="low_limit">
+          <property name="font">
+           <font>
+            <pointsize>8</pointsize>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="value_layout" stretch="1,1,1,0">
+        <property name="spacing">
+         <number>10</number>
+        </property>
+        <item>
+         <widget class="PyDMLabel" name="user_readback">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="whatsThis">
+           <string/>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="set_value">
+          <property name="minimumSize">
+           <size>
+            <width>20</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="tweak_layout" stretch="0,1,0">
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QToolButton" name="tweak_negative">
+            <property name="minimumSize">
+             <size>
+              <width>25</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>-</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="tweak_value">
+            <property name="minimumSize">
+             <size>
+              <width>60</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="tweak_positive">
+            <property name="minimumSize">
+             <size>
+              <width>25</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>+</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="stop_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>175</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
+          </property>
+          <property name="text">
+           <string>Stop</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+          <property name="default">
+           <bool>false</bool>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="high_limit_layout" stretch="0,0,1">
+        <property name="spacing">
+         <number>5</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <item alignment="Qt::AlignHCenter">
+         <widget class="PyDMByteIndicator" name="high_limit_switch">
+          <property name="minimumSize">
+           <size>
+            <width>25</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="whatsThis">
+           <string>
     Widget for graphical representation of bits from an integer number
     with support for Channels and more from PyDM
 
@@ -316,72 +326,73 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">margin: 0px;</string>
-         </property>
-         <property name="onColor" stdset="0">
-          <color>
-           <red>239</red>
-           <green>246</green>
-           <blue>20</blue>
-          </color>
-         </property>
-         <property name="offColor" stdset="0">
-          <color>
-           <red>178</red>
-           <green>188</green>
-           <blue>17</blue>
-          </color>
-         </property>
-         <property name="orientation" stdset="0">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="showLabels" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="circles" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="shift" stdset="0">
-          <number>0</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMLabel" name="high_limit">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-    </layout>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">margin: 0px;</string>
+          </property>
+          <property name="onColor" stdset="0">
+           <color>
+            <red>239</red>
+            <green>246</green>
+            <blue>20</blue>
+           </color>
+          </property>
+          <property name="offColor" stdset="0">
+           <color>
+            <red>178</red>
+            <green>188</green>
+            <blue>17</blue>
+           </color>
+          </property>
+          <property name="orientation" stdset="0">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="showLabels" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="circles" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="shift" stdset="0">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="PyDMLabel" name="high_limit">
+          <property name="font">
+           <font>
+            <pointsize>8</pointsize>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/typhon/ui/positioner.ui
+++ b/typhon/ui/positioner.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>299</width>
-    <height>167</height>
+    <height>141</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -143,29 +143,10 @@
       </layout>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="value_layout" stretch="0,1,1,1,0">
+      <layout class="QVBoxLayout" name="value_layout" stretch="1,1,1,0">
        <property name="spacing">
         <number>10</number>
        </property>
-       <item>
-        <widget class="QProgressBar" name="progress_bar">
-         <property name="styleSheet">
-          <string notr="true"/>
-         </property>
-         <property name="maximum">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>4</number>
-         </property>
-         <property name="textVisible">
-          <bool>true</bool>
-         </property>
-         <property name="textDirection">
-          <enum>QProgressBar::TopToBottom</enum>
-         </property>
-        </widget>
-       </item>
        <item>
         <widget class="PyDMLabel" name="user_readback">
          <property name="sizePolicy">

--- a/typhon/ui/style.qss
+++ b/typhon/ui/style.qss
@@ -50,6 +50,18 @@ PyDMLogDisplay > QPlainTextEdit {
     font: 10px normal;
 }
 
-TyphonPositionerWidget[moving="true"] PyDMLabel{
-    background-color: green;
+TyphonPositionerWidget[moving="true"] .QFrame {
+    border: 2px solid yellow;
+}
+
+TyphonPositionerWidget[moving="false"] .QFrame {
+    border: 2px solid transparent;
+}
+
+TyphonPositionerWidget[moving="false"][successful_move="true"] .QFrame {
+    border: 2px solid green;
+}
+
+TyphonPositionerWidget[moving="false"][failed_move="true"] .QFrame {
+    border: 2px solid red;
 }

--- a/typhon/ui/style.qss
+++ b/typhon/ui/style.qss
@@ -49,3 +49,7 @@ QListWidget::item:!selected:hover {
 PyDMLogDisplay > QPlainTextEdit {
     font: 10px normal;
 }
+
+TyphonPositionerWidget[moving="true"] PyDMLabel{
+    background-color: green;
+}

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -256,3 +256,14 @@ def raise_to_operator(exc):
     err_msg.setDetailedText(handle.read())
     err_msg.exec_()
     return err_msg
+
+
+def reload_widget_stylesheet(widget, cascade=False):
+    """Reload the stylsheet of provided widget"""
+    widget.style().unpolish(widget)
+    widget.style().polish(widget)
+    widget.update()
+    if cascade:
+        for child in widget.children():
+            if isinstance(child, QWidget):
+                reload_widget_stylesheet(child, cascade=True)

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -247,7 +247,7 @@ def raise_to_operator(exc):
     """Utility function to show an Exception to a user"""
     logger.error("Reporting error %r to user ...", exc)
     err_msg = QMessageBox()
-    err_msg.setText(repr(exc))
+    err_msg.setText(f'{exc.__class__.__name__}: {exc}')
     err_msg.setWindowTitle(type(exc).__name__)
     err_msg.setIcon(QMessageBox.Critical)
     handle = io.StringIO()

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -259,7 +259,7 @@ def raise_to_operator(exc):
 
 
 def reload_widget_stylesheet(widget, cascade=False):
-    """Reload the stylsheet of provided widget"""
+    """Reload the stylesheet of the provided widget"""
     widget.style().unpolish(widget)
     widget.style().polish(widget)
     widget.update()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added `TyphonSetWidget` for widgets that have `set` methods which take numbers. It also has widgets for limit switches, soft limits if those signals exist, otherwise they are hidden. I also created full templates that use this widget so they can be utilized easily via stylesheet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #37 

## Tests
Full test file added

## Screenshots (if appropriate):
![set_widget](https://user-images.githubusercontent.com/25753048/50938230-2138d500-142c-11e9-9672-f8a26232a3c2.gif)