### PR TITLE
API Breaks and Deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ by the operator:
 * ``TyphonSuite``: The overall view for a Typhon window. It allows the
 operator to view all of the loaded components and tools
 
-* ``TyphonDisplay``: This is the widget created for a standard
+* ``TyphonDeviceDisplay``: This is the widget created for a standard
 ``ophyd.Device``. Signals are organized based on their
 ``Kind`` and description.
 

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -6,7 +6,7 @@ by the operator:
 
 * **TyphonSuite** : The overall view for a Typhon window. It allows the
   operator to view all of the loaded components and tools.
-* **TyphonDisplay** : This is the widget created for a standard
+* **TyphonDeviceDisplay** : This is the widget created for a standard
   ``ophyd.Device``. Signals are organized based on their ``Kind`` and
   description.
 * **typhon.tools** : These are widgets that interface with external

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -65,10 +65,10 @@ We also have these signals grouped by their importance to operation, each with
 a terse human legible description of what the PV represents.
 
 Typhon takes advantage of this to generate a concise PyDM user display. The
-:class:`.DeviceDisplay` uses the signal groups; ``read_attrs``,
+:class:`.TyphonDeviceDisplay` uses the signal groups; ``read_attrs``,
 ``configuration_attrs`` and ``hints`` to generate plots and widgets based on
 the type and class of EPICSSignals. In order to best select the widget types,
-:class:`.DeviceDisplay` attempts to connect to all of the PVs listed. If this
+:class:`.TyphonDeviceDisplay` attempts to connect to all of the PVs listed. If this
 is not possible, there are ways to manually configure which widget will be
 used. Simply invoke your device and then create your ``PyDMApplication`` and
 widget

--- a/docs/source/display.rst
+++ b/docs/source/display.rst
@@ -2,7 +2,7 @@
 Display Types
 ==============
 Typhon has two major widgets that users are expected to interface with. The
-first is the :class:`.TyphonDisplay`, which shows device information, and
+first is the :class:`.TyphonDeviceDisplay`, which shows device information, and
 :class:`.TyphonSuite` which contains multiple devices and tools. This is the
 barebones implementation. No signals, or widgets are automatically populated in
 the screen. In fact, by default most of the widgets will be hidden. You can
@@ -16,10 +16,8 @@ TyphonSuite
 .. autoclass:: typhon.TyphonSuite
    :members:
 
-TyphonDisplay
-=============
+TyphonDeviceDisplay
+===================
 
-.. autoclass:: typhon.TyphonDisplay
+.. autoclass:: typhon.TyphonDeviceDisplay
    :members:
-
-.. autofunction:: typhon.DeviceDisplay

--- a/docs/source/python_methods.rst
+++ b/docs/source/python_methods.rst
@@ -5,7 +5,7 @@ Including Python Code
 
 Adding Methods
 ==============
-Each :class:`.TyphonDisplay` has an :attr:`.method_panel`. You can add methods
+Each :class:`.TyphonDeviceDisplay` has an :attr:`.method_panel`. You can add methods
 manually or pass them in via the constructor. In order to make the appropriate
 widgets,  the function signature is examined. For example lets make a mock
 function:

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -4,9 +4,9 @@ Supported Tools
 
 In experimental environments there are a variety of external tools and 
 applications that are critical to day to day operation. Typhon hopes to
-integrate many of these services into the :class:`.DeviceDisplay` for ease of
-operation. This approach has two advantages; the first is that getting to
-helpful tools requires fewer clicks and therefore less time, secondly, if we
+integrate many of these services into the :class:`.TyphonDeviceDisplay` for
+ease of operation. This approach has two advantages; the first is that getting
+to helpful tools requires fewer clicks and therefore less time, secondly, if we
 assume that the context in which they want to use the external tool includes
 this device, we can pre-populate many of the fields for them.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def test_cli_happi_cfg(monkeypatch, qtbot, happi_cfg):
 def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
     with open('test.qss', 'w+') as handle:
-        handle.write("TyphonDisplay {qproperty-force_template: 'test.ui'}")
+        handle.write("TyphonDeviceDisplay {qproperty-force_template: 'test.ui'}")
     style = qapp.styleSheet()
     suite = typhon_cli(['test_motor', '--stylesheet', 'test.qss',
                         '--happi-cfg', happi_cfg])

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -1,5 +1,5 @@
-from typhon.designer import TyphonPanelPlugin
+from typhon.designer import TyphonSignalPanelPlugin
 
 
 def test_typhon_panel_plugin_smoke():
-    tpp = TyphonPanelPlugin()
+    tpp = TyphonSignalPanelPlugin()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -2,7 +2,7 @@ import os.path
 
 import pytest
 
-from typhon import TyphonDisplay
+from typhon import TyphonDeviceDisplay
 from typhon.utils import clean_attr
 
 from .conftest import show_widget
@@ -10,14 +10,14 @@ from .conftest import show_widget
 
 @pytest.fixture(scope='function')
 def display(qtbot):
-    display = TyphonDisplay()
+    display = TyphonDeviceDisplay()
     qtbot.addWidget(display)
     return display
 
 
 @show_widget
 def test_device_display(device, motor, qtbot):
-    panel = TyphonDisplay.from_device(motor)
+    panel = TyphonDeviceDisplay.from_device(motor)
     panel_main = panel._main_widget
     qtbot.addWidget(panel)
     # We have all our signals
@@ -76,7 +76,7 @@ def test_display_force_template(display):
     assert display.current_template == 'tst.ui'
 
 def test_display_with_channel(client, qtbot):
-    panel = TyphonDisplay()
+    panel = TyphonDeviceDisplay()
     qtbot.addWidget(panel)
     panel.channel = 'happi://test_motor'
     assert panel.channel == 'happi://test_motor'

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -18,7 +18,7 @@ from qtpy.QtGui import QColor
 # Module #
 ##########
 from typhon import register_signal
-from typhon.tools.plot import TyphonTimePlot, DeviceTimePlot
+from typhon.tools.plot import TyphonTimePlot
 from typhon.utils import channel_from_signal
 
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import QWidget
 ###########
 # Package #
 ###########
-from typhon.signal import SignalPanel, TyphonPanel
+from typhon.signal import SignalPanel, TyphonSignalPanel
 from .conftest import show_widget, RichSignal, DeadSignal
 
 @using_fake_epics_pv
@@ -96,7 +96,7 @@ def test_add_pv(qtbot):
 
 @show_widget
 def test_typhon_panel(qapp, client, qtbot):
-    panel = TyphonPanel()
+    panel = TyphonSignalPanel()
     qtbot.addWidget(panel)
     # Setting Kind without device doesn't explode
     panel.showConfig = False
@@ -129,7 +129,7 @@ def test_typhon_panel(qapp, client, qtbot):
 
 @show_widget
 def test_typhon_panel_sorting(qapp, client, qtbot):
-    panel = TyphonPanel()
+    panel = TyphonSignalPanel()
     qtbot.addWidget(panel)
     # Sort by name
     panel.sortBy = panel.SignalOrder.byName

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -20,7 +20,7 @@ from .conftest import show_widget
 
 @pytest.fixture(scope='function')
 def suite(qtbot, device):
-    suite = TyphonSuite.from_device(device, tools=dict())
+    suite = TyphonSuite.from_device(device, tools=None)
     qtbot.addWidget(suite)
     return suite
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import QDockWidget
 ###########
 from typhon.utils import clean_name
 from typhon.suite import TyphonSuite, DeviceParameter
-from typhon.display import TyphonDisplay
+from typhon.display import TyphonDeviceDisplay
 from .conftest import show_widget
 
 
@@ -54,7 +54,7 @@ def test_suite_get_subdisplay_by_device(suite, device):
 
 def test_suite_subdisplay_parentage(suite, device):
     display = suite.get_subdisplay(device)
-    assert display in suite.findChildren(TyphonDisplay)
+    assert display in suite.findChildren(TyphonDeviceDisplay)
 
 def test_suite_get_subdisplay_by_name(suite, device):
     display = suite.get_subdisplay(device.name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from ophyd import Device, Component as Cpt, Kind
 import pytest
 
 import typhon
-from typhon.utils import (use_stylesheet, clean_name, grab_hints, grab_kind,
+from typhon.utils import (use_stylesheet, clean_name, grab_kind,
                           TyphonBase, raise_to_operator)
 
 class NestedDevice(Device):
@@ -26,12 +26,6 @@ def test_clean_name():
                       strip_parent=False) == 'test radial phi'
     assert clean_name(device.radial.phi, strip_parent=True) == 'phi'
     assert clean_name(device.radial.phi, strip_parent=device) == 'radial phi'
-
-
-def test_grab_hints(motor):
-    hint_names = [cpt.name for cpt in grab_hints(motor)]
-    assert all([field in hint_names
-                for field in motor.hints['fields']])
 
 
 def test_stylesheet(qtbot):

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,9 +1,9 @@
 __all__ = ['TyphonDisplay', 'DeviceDisplay', 'use_stylesheet',
-           'register_signal', 'TyphonSuite', 'TyphonPanel',
+           'register_signal', 'TyphonSuite', 'TyphonSignalPanel',
            'TyphonPositionerWidget']
 from .display import TyphonDisplay, DeviceDisplay
 from .suite import TyphonSuite
-from .signal import TyphonPanel
+from .signal import TyphonSignalPanel
 from .positioner import TyphonPositionerWidget
 from .utils import use_stylesheet
 from .plugins import register_signal

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,7 +1,7 @@
-__all__ = ['TyphonDisplay', 'DeviceDisplay', 'use_stylesheet',
+__all__ = ['TyphonDeviceDisplay', 'use_stylesheet',
            'register_signal', 'TyphonSuite', 'TyphonSignalPanel',
            'TyphonPositionerWidget']
-from .display import TyphonDisplay, DeviceDisplay
+from .display import TyphonDeviceDisplay
 from .suite import TyphonSuite
 from .signal import TyphonSignalPanel
 from .positioner import TyphonPositionerWidget

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -74,7 +74,9 @@ def typhon_cli(args):
             app.setStyleSheet(handle.read())
 
     suite = typhon.TyphonSuite()
-
+    logger.info("Loading Tools ...")
+    for name, tool in suite.default_tools.items():
+        suite.add_tool(name, tool())
     # Load and add each device
     for device in args.devices:
         logger.info("Loading %r ...", device)

--- a/typhon/designer.py
+++ b/typhon/designer.py
@@ -2,7 +2,7 @@ import logging
 
 from pydm.widgets.qtplugin_base import qtplugin_factory
 
-from .signal import TyphonPanel
+from .signal import TyphonSignalPanel
 from .display import TyphonDisplay
 from .func import TyphonMethodButton
 from .positioner import TyphonPositionerWidget
@@ -10,7 +10,7 @@ from .positioner import TyphonPositionerWidget
 logger = logging.getLogger(__name__)
 
 logging.info("Loading Typhon QtDesigner plugins ...")
-TyphonPanelPlugin = qtplugin_factory(TyphonPanel)
+TyphonSignalPanelPlugin = qtplugin_factory(TyphonSignalPanel)
 TyphonDisplayPlugin = qtplugin_factory(TyphonDisplay)
 TyphonMethodButtonPlugin = qtplugin_factory(TyphonMethodButton)
 TyphonPositionerWidgetPlugin = qtplugin_factory(TyphonPositionerWidget)

--- a/typhon/designer.py
+++ b/typhon/designer.py
@@ -3,7 +3,7 @@ import logging
 from pydm.widgets.qtplugin_base import qtplugin_factory
 
 from .signal import TyphonSignalPanel
-from .display import TyphonDisplay
+from .display import TyphonDeviceDisplay
 from .func import TyphonMethodButton
 from .positioner import TyphonPositionerWidget
 
@@ -11,6 +11,6 @@ logger = logging.getLogger(__name__)
 
 logging.info("Loading Typhon QtDesigner plugins ...")
 TyphonSignalPanelPlugin = qtplugin_factory(TyphonSignalPanel)
-TyphonDisplayPlugin = qtplugin_factory(TyphonDisplay)
+TyphonDeviceDisplayPlugin = qtplugin_factory(TyphonDeviceDisplay)
 TyphonMethodButtonPlugin = qtplugin_factory(TyphonMethodButton)
 TyphonPositionerWidgetPlugin = qtplugin_factory(TyphonPositionerWidget)

--- a/typhon/designer.py
+++ b/typhon/designer.py
@@ -8,9 +8,14 @@ from .func import TyphonMethodButton
 from .positioner import TyphonPositionerWidget
 
 logger = logging.getLogger(__name__)
+logger.info("Loading Typhon QtDesigner plugins ...")
 
-logging.info("Loading Typhon QtDesigner plugins ...")
-TyphonSignalPanelPlugin = qtplugin_factory(TyphonSignalPanel)
-TyphonDeviceDisplayPlugin = qtplugin_factory(TyphonDeviceDisplay)
-TyphonMethodButtonPlugin = qtplugin_factory(TyphonMethodButton)
-TyphonPositionerWidgetPlugin = qtplugin_factory(TyphonPositionerWidget)
+group_name = 'Typhon Widgets'
+TyphonSignalPanelPlugin = qtplugin_factory(TyphonSignalPanel,
+                                           group=group_name)
+TyphonDeviceDisplayPlugin = qtplugin_factory(TyphonDeviceDisplay,
+                                             group=group_name)
+TyphonMethodButtonPlugin = qtplugin_factory(TyphonMethodButton,
+                                            group=group_name)
+TyphonPositionerWidgetPlugin = qtplugin_factory(TyphonPositionerWidget,
+                                                group=group_name)

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -30,7 +30,7 @@ class DisplayTypes:
         return Enum('TemplateEnum', entries)
 
 
-class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
+class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     """
     Main Panel display for a signal Ophyd Device
 
@@ -175,7 +175,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
 
     def add_device(self, device, macros=None):
         """
-        Add a Device and signals to the TyphonDisplay
+        Add a Device and signals to the TyphonDeviceDisplay
 
         Parameters
         ----------
@@ -210,7 +210,7 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     @classmethod
     def from_device(cls, device, template=None, macros=None):
         """
-        Create a new TyphonDisplay from a Device
+        Create a new TyphonDeviceDisplay from a Device
 
         Loads the signals in to the appropriate positions and sets the title to
         a cleaned version of the device name

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -236,6 +236,3 @@ class TyphonDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     def _tx(self, value):
         """Receive information from happi channel"""
         self.add_device(value['obj'], macros=value['md'])
-
-
-DeviceDisplay = TyphonDisplay.from_device

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -198,7 +198,7 @@ class SignalOrder:
     byName = 1
 
 
-class TyphonPanel(TyphonBase, TyphonDesignerMixin, SignalOrder):
+class TyphonSignalPanel(TyphonBase, TyphonDesignerMixin, SignalOrder):
     """
     Panel of Signals for Device
     """

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import QDockWidget, QHBoxLayout, QVBoxLayout, QWidget
 ###########
 # Package #
 ###########
-from .display import TyphonDisplay
+from .display import TyphonDeviceDisplay
 from .utils import clean_name, TyphonBase, flatten_tree
 from .widgets import TyphonSidebarItem, SubDisplay
 from .tools import TyphonTimePlot, TyphonLogDisplay, TyphonConsole
@@ -58,12 +58,12 @@ class DeviceParameter(SidebarParameter):
                 else:
                     child_name = clean_name(subdevice,
                                             strip_parent=subdevice.root)
-                    child_display = TyphonDisplay.from_device(subdevice)
+                    child_display = TyphonDeviceDisplay.from_device(subdevice)
                     children.append(SidebarParameter(value=child_display,
                                                      name=child_name,
                                                      embeddable=True))
         opts['children'] = children
-        super().__init__(value=TyphonDisplay.from_device(device),
+        super().__init__(value=TyphonDeviceDisplay.from_device(device),
                          embeddable=opts.pop('embeddable', True),
                          **opts)
 
@@ -278,7 +278,7 @@ class TyphonSuite(TyphonBase):
 
     @property
     def tools(self):
-        """Tools loaded into the DeviceDisplay"""
+        """Tools loaded into the TyphonDeviceDisplay"""
         if 'Tools' in self.top_level_groups:
             return [param.value()
                     for param in self.top_level_groups['Tools'].childs]
@@ -321,7 +321,7 @@ class TyphonSuite(TyphonBase):
                            'Console': TyphonConsole},
                     **kwargs):
         """
-        Create a new TyphonDisplay from an ophyd.Device
+        Create a new TyphonDeviceDisplay from an ophyd.Device
 
         Parameters
         ----------

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -79,6 +79,10 @@ class TyphonSuite(TyphonBase):
     ----------
     parent : QWidget, optional
     """
+    default_tools = {'Log': TyphonLogDisplay,
+                     'StripTool': TyphonTimePlot,
+                     'Console': TyphonConsole}
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         # Setup parameter tree
@@ -316,10 +320,7 @@ class TyphonSuite(TyphonBase):
 
     @classmethod
     def from_device(cls, device, parent=None,
-                    tools={'Log': TyphonLogDisplay,
-                           'StripTool': TyphonTimePlot,
-                           'Console': TyphonConsole},
-                    **kwargs):
+                    tools=dict(), **kwargs):
         """
         Create a new TyphonDeviceDisplay from an ophyd.Device
 
@@ -333,17 +334,23 @@ class TyphonSuite(TyphonBase):
         parent: QWidgets
 
         tools: dict, optional
-            Tools to load for the object. ``dict`` should be name, class pairs
+            Tools to load for the object. ``dict`` should be name, class pairs.
+            By default these will be ``.default_tools``, but ``None`` can be
+            passed to avoid tool loading completely.
 
         kwargs:
             Passed to :meth:`TyphonSuite.add_device`
         """
         display = cls(parent=parent)
-        for name, tool in tools.items():
-            try:
-                display.add_tool(name, tool())
-            except Exception:
-                logger.exception("Unable to load %s", type(tool))
+        if tools is not None:
+            if not tools:
+                logger.debug("Using default TyphonSuite tools ...")
+                tools = cls.default_tools
+                for name, tool in tools.items():
+                    try:
+                        display.add_tool(name, tool())
+                    except Exception:
+                        logger.exception("Unable to load %s", type(tool))
         display.add_device(device, **kwargs)
         display.show_subdisplay(device)
         return display

--- a/typhon/tools/plot.py
+++ b/typhon/tools/plot.py
@@ -111,7 +111,7 @@ class TyphonTimePlot(TyphonBase):
             Name of the curve to remove. This should match the name given
             during the call of :meth:`.add_curve`
         """
-        logger.debug("Removing %s from DeviceTimePlot ...", name)
+        logger.debug("Removing %s from TyphonTimePlot ...", name)
         self.timechart.remove_curve(name)
 
     @Slot()

--- a/typhon/tools/plot.py
+++ b/typhon/tools/plot.py
@@ -5,7 +5,6 @@ Typhon Plotting Interface
 # Standard #
 ############
 import logging
-from warnings import warn
 
 ###############
 # Third Party #
@@ -160,9 +159,3 @@ class TyphonTimePlot(TyphonBase):
                         logger.exception("Unable to add %s to "
                                          "plot-able signals",
                                          component)
-
-
-def DeviceTimePlot(device, parent=None):
-    warn("DeviceTimePlot has been deprecated. "
-         "Use TyphonTimePlot.from_device instead.")
-    return TyphonTimePlot.from_device(device, parent=parent)

--- a/typhon/ui/detailed_positioner.ui
+++ b/typhon/ui/detailed_positioner.ui
@@ -177,7 +177,7 @@
             <number>2</number>
            </property>
            <item>
-            <widget class="TyphonPanel" name="normal_panel">
+            <widget class="TyphonSignalPanel" name="normal_panel">
              <property name="toolTip">
               <string/>
              </property>
@@ -254,7 +254,7 @@
             <number>2</number>
            </property>
            <item>
-            <widget class="TyphonPanel" name="config_panel">
+            <widget class="TyphonSignalPanel" name="config_panel">
              <property name="toolTip">
               <string/>
              </property>
@@ -331,7 +331,7 @@
             <number>2</number>
            </property>
            <item>
-            <widget class="TyphonPanel" name="misc_panel">
+            <widget class="TyphonSignalPanel" name="misc_panel">
              <property name="toolTip">
               <string/>
              </property>
@@ -363,7 +363,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphonPanel</class>
+   <class>TyphonSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhon.signal</header>
   </customwidget>

--- a/typhon/ui/detailed_screen.ui
+++ b/typhon/ui/detailed_screen.ui
@@ -76,7 +76,7 @@
     </widget>
    </item>
    <item>
-    <widget class="TyphonPanel" name="read_panel">
+    <widget class="TyphonSignalPanel" name="read_panel">
      <property name="toolTip">
       <string/>
      </property>
@@ -187,7 +187,7 @@
             <number>2</number>
            </property>
            <item>
-            <widget class="TyphonPanel" name="config_panel">
+            <widget class="TyphonSignalPanel" name="config_panel">
              <property name="toolTip">
               <string/>
              </property>
@@ -264,7 +264,7 @@
             <number>2</number>
            </property>
            <item>
-            <widget class="TyphonPanel" name="misc_panel">
+            <widget class="TyphonSignalPanel" name="misc_panel">
              <property name="toolTip">
               <string/>
              </property>
@@ -296,7 +296,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphonPanel</class>
+   <class>TyphonSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhon.signal</header>
   </customwidget>

--- a/typhon/ui/embedded_screen.ui
+++ b/typhon/ui/embedded_screen.ui
@@ -142,7 +142,7 @@
     </widget>
    </item>
    <item>
-    <widget class="TyphonPanel" name="hint_panel">
+    <widget class="TyphonSignalPanel" name="hint_panel">
      <property name="toolTip">
       <string/>
      </property>
@@ -179,7 +179,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphonPanel</class>
+   <class>TyphonSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhon.signal</header>
   </customwidget>

--- a/typhon/ui/engineering_screen.ui
+++ b/typhon/ui/engineering_screen.ui
@@ -112,7 +112,7 @@
         </widget>
        </item>
        <item alignment="Qt::AlignTop">
-        <widget class="TyphonPanel" name="read_panel">
+        <widget class="TyphonSignalPanel" name="read_panel">
          <property name="toolTip">
           <string/>
          </property>
@@ -128,7 +128,7 @@
           <bool>false</bool>
          </property>
          <property name="sortBy" stdset="0">
-          <enum>TyphonPanel::byName</enum>
+          <enum>TyphonSignalPanel::byName</enum>
          </property>
         </widget>
        </item>
@@ -180,7 +180,7 @@
         </widget>
        </item>
        <item alignment="Qt::AlignTop">
-        <widget class="TyphonPanel" name="config_panel">
+        <widget class="TyphonSignalPanel" name="config_panel">
          <property name="toolTip">
           <string/>
          </property>
@@ -199,7 +199,7 @@
           <bool>false</bool>
          </property>
          <property name="sortBy" stdset="0">
-          <enum>TyphonPanel::byName</enum>
+          <enum>TyphonSignalPanel::byName</enum>
          </property>
         </widget>
        </item>
@@ -251,7 +251,7 @@
         </widget>
        </item>
        <item alignment="Qt::AlignTop">
-        <widget class="TyphonPanel" name="misc_panel">
+        <widget class="TyphonSignalPanel" name="misc_panel">
          <property name="toolTip">
           <string/>
          </property>
@@ -270,7 +270,7 @@
           <bool>false</bool>
          </property>
          <property name="sortBy" stdset="0">
-          <enum>TyphonPanel::byName</enum>
+          <enum>TyphonSignalPanel::byName</enum>
          </property>
         </widget>
        </item>
@@ -295,7 +295,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphonPanel</class>
+   <class>TyphonSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhon.signal</header>
   </customwidget>

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -10,7 +10,6 @@ import logging
 import os.path
 import random
 import traceback
-import warnings
 
 ############
 # External #
@@ -70,12 +69,6 @@ def grab_kind(device, kind):
         if cpt.kind >= kind and not isinstance(cpt, Device):
             signals.append((attr, cpt))
     return signals
-
-
-def grab_hints(device):
-    """Grab all the hinted signals from a Device"""
-    warnings.warn("This will be deprecated. Use ``grab_kind``.")
-    return [cpt[1] for cpt in grab_kind(device, kind=Kind.hinted)]
 
 
 def channel_name(pv, protocol='ca'):


### PR DESCRIPTION
Last round of API breaks I wanted to get in before I tag:

## API
I really didn't like how vague the names were for `TyphonPanel` and `TyphonDisplay`. They convey very little meaning. They are now `TyphonDeviceDisplay` and `TyphonSignalPanel`. A little wordier but easier to tell what they are going to do

## Deprecations
After a conversation with @klauer, lugging a bunch of API from `v0.1.0` around probably isn't necessary. Now that every `typhon` widget has `.from_device` class constructor I don't need factory functions so that removes any need for `DeviceDisplay` and `DeviceTimePlot`. There was also an old utility called `grab_hints` which has been replaced by the more general `grab_kind`

Also a few small fixes:
*  The `typhon` command line function was not loading any of the tools
*  The `typhon` widgets in the Designer were under the "PyDM Widgets" group