### PR TITLE
Suite saving

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,14 +67,14 @@ before_script:
   - sleep 1
 
 script:
-  - coverage run run_tests.py
+  - coverage run run_tests.py --show-capture=no
   - coverage report -m
     #- coverage report -m
   - flake8 typhon
   # Test again but with installed version
   - mkdir notest
   - mv typhon/*.* notest
-  - python run_tests.py
+  - python run_tests.py --show-capture=no
   - mv notest/* typhon
   - rmdir notest
   # Build docs

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -27,6 +27,7 @@ alternatively and be constructed using the ``from_device`` classmethod.
 
 .. autoclass:: typhon.utils.TyphonBase
    :members:
+   :noindex:
 
 
 Interpreting a Device

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,3 +51,4 @@ Related Projects
    display.rst
    widgets.rst
    plugins.rst
+   utils.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ Related Projects
 
    basic_usage.rst
    tools.rst
+   save.rst
    connections.rst
    python_methods.rst
 

--- a/docs/source/save.rst
+++ b/docs/source/save.rst
@@ -24,7 +24,7 @@ to disk.
 There are two major ways to use this created file:
 
 1. Execute the Python file from the command line. This will route the call
-   through the standard :func:`.typhon.cli.typhon_cli` meaning all options
+   through the standard :func:`.cli.typhon_cli` meaning all options
    described there are also available.
 
 .. code:: bash

--- a/docs/source/save.rst
+++ b/docs/source/save.rst
@@ -3,28 +3,15 @@ Saving and Loading
 ##################
 :class:`.TyphonSuite` objects can be stored for later use. The devices that
 were loaded into the suite via :meth:`.TyphonSuite.add_device` will be added
-once again assuming that they are stored in a ``happi`` database. When you call
-:meth:`.TyphonSuite.save` a Python file with the template shown below is saved
-to disk.
+once again assuming that they are stored in a ``happi`` database.
 
-.. code:: python
-
-    import sys
-    import typhon.cli
-
-    devices = {devices}
-
-    def create_suite(cfg=None):
-        return typhon.cli.create_suite(devices, cfg=cfg)
-
-    if __name__ == '__main__':
-        typhon.cli.typhon_cli(devices + sys.argv[1:])
-
+.. automethod:: typhon.TyphonSuite.save
+   :noindex:
 
 There are two major ways to use this created file:
 
 1. Execute the Python file from the command line. This will route the call
-   through the standard :func:`.cli.typhon_cli` meaning all options
+   through the standard :mod:`typhon.cli` meaning all options
    described there are also available.
 
 .. code:: bash

--- a/docs/source/save.rst
+++ b/docs/source/save.rst
@@ -1,0 +1,64 @@
+##################
+Saving and Loading
+##################
+:class:`.TyphonSuite` objects can be stored for later use. The devices that
+were loaded into the suite via :meth:`.TyphonSuite.add_device` will be added
+once again assuming that they are stored in a ``happi`` database. When you call
+:meth:`.TyphonSuite.save` a Python file with the template shown below is saved
+to disk.
+
+.. code:: python
+
+    import sys
+    import typhon.cli
+
+    devices = {devices}
+
+    def create_suite(cfg=None):
+        return typhon.cli.create_suite(devices, cfg=cfg)
+
+        if __name__ == '__main__':
+            typhon.cli.typhon_cli(devices + sys.argv[1:])
+
+
+There are two major ways to use this created file:
+
+1. Execute the Python file from the command line. This will route the call
+   through the standard :func:`.typhon.cli.typhon_cli` meaning all options
+   described there are also available.
+
+.. code:: bash
+
+   $ python saved_suite.py
+
+
+2. The ``create_suite`` method generated in the saved file can be used to
+   re-create the :class:`.TyphonSuite` in an already running Python process.
+   Typhon provides the :func:`.load_suite` function to import the provided
+   Python file and execute the stored ``create_suite`` method.  This is useful
+   if you want to use the file to embed a saved :class:`.TyphonSuite` inside
+   another PyQt window for instance, or load multiple suites at once.
+
+
+.. code:: python
+
+   from qtpy.QtWidgets import QApplication
+   from typhon import load_suite
+
+   app = QApplication([])
+   saved_suite = load_suite('saved_suite.py')
+
+   saved_suite.show()
+   app.exec_()
+
+ 
+.. note::
+
+   The saved file only stores a reference to the devices loaded into the
+   ``TyphonSuite`` by name. It is assumed that these devices will be available
+   under the same name via the configured ``happi`` database when
+   ``load_suite`` is called. If the device has a different name in the database
+   or you have configured a different ``happi`` database to be used your
+   devices will not be loaded properly.
+
+  

--- a/docs/source/save.rst
+++ b/docs/source/save.rst
@@ -17,8 +17,8 @@ to disk.
     def create_suite(cfg=None):
         return typhon.cli.create_suite(devices, cfg=cfg)
 
-        if __name__ == '__main__':
-            typhon.cli.typhon_cli(devices + sys.argv[1:])
+    if __name__ == '__main__':
+        typhon.cli.typhon_cli(devices + sys.argv[1:])
 
 
 There are two major ways to use this created file:

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,0 +1,6 @@
+#################
+Utility Functions
+#################
+
+.. automodule:: typhon.utils
+   :members:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ def test_cli_happi_cfg(monkeypatch, qtbot, happi_cfg):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
     suite = typhon_cli(['test_motor', '--happi-cfg', happi_cfg])
     qtbot.addWidget(suite)
+    assert suite.isVisible()
     assert 'test_motor' == suite.devices[0].name
 
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,6 +1,9 @@
 ############
 # Standard #
 ############
+import io
+from pathlib import Path
+import tempfile
 
 ############
 # External #
@@ -12,7 +15,8 @@ from qtpy.QtWidgets import QDockWidget
 ###########
 # Package #
 ###########
-from typhon.utils import clean_name
+import typhon.suite
+from typhon.utils import clean_name, save_suite
 from typhon.suite import TyphonSuite, DeviceParameter
 from typhon.display import TyphonDeviceDisplay
 from .conftest import show_widget
@@ -138,3 +142,11 @@ def test_hide_embedded_display(suite, device):
     display = suite.get_subdisplay(device.x)
     assert suite.embedded_dock is None
     assert display.isHidden()
+
+
+def test_suite_save_util(suite, device):
+    handle = io.StringIO()
+    save_suite(suite, handle)
+    handle.seek(0)
+    devices = [device.name for device in suite.devices]
+    assert str(devices) in handle.read()

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -2,6 +2,7 @@
 # Standard #
 ############
 import io
+import os
 from pathlib import Path
 import tempfile
 
@@ -161,6 +162,7 @@ def test_suite_save(suite, monkeypatch):
     assert tfile.exists()
     devices = [device.name for device in suite.devices]
     assert str(devices) in open(str(tfile), 'r').read()
+    os.remove(str(tfile))
 
 
 def test_suite_save_cancel_smoke(suite, monkeypatch):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -150,3 +150,21 @@ def test_suite_save_util(suite, device):
     handle.seek(0)
     devices = [device.name for device in suite.devices]
     assert str(devices) in handle.read()
+
+
+def test_suite_save(suite, monkeypatch):
+    tfile = Path(tempfile.gettempdir()) / 'test.py'
+    monkeypatch.setattr(typhon.suite.QFileDialog,
+                        'getSaveFileName',
+                        lambda *args: (str(tfile), str(tfile)))
+    suite.save()
+    assert tfile.exists()
+    devices = [device.name for device in suite.devices]
+    assert str(devices) in open(str(tfile), 'r').read()
+
+
+def test_suite_save_cancel_smoke(suite, monkeypatch):
+    monkeypatch.setattr(typhon.suite.QFileDialog,
+                        'getSaveFileName',
+                        lambda *args: None)
+    suite.save()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,6 +90,7 @@ def test_load_suite(qtbot):
     qtbot.addWidget(suite)
     assert isinstance(suite, typhon.TyphonSuite)
     assert suite.devices == []
+    os.remove(module_file)
 
 
 def test_load_suite_with_bad_py_file():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
 import os
+import pathlib
+import tempfile
 
 from qtpy.QtCore import QRect
 from qtpy.QtGui import QPaintEvent
@@ -8,7 +10,8 @@ import pytest
 
 import typhon
 from typhon.utils import (use_stylesheet, clean_name, grab_kind,
-                          TyphonBase, raise_to_operator)
+                          TyphonBase, raise_to_operator, load_suite,
+                          saved_template)
 
 class NestedDevice(Device):
     phi = Cpt(Device)
@@ -74,3 +77,21 @@ def test_raise_to_operator_msg(monkeypatch, qtbot):
     qtbot.addWidget(exc_dialog)
     assert exc_dialog is not None
     assert 'ZeroDivisionError' in exc_dialog.text()
+
+
+def test_load_suite(qtbot):
+    # Setup new saved file
+    module = saved_template.format(devices=[])
+    module_file = str(pathlib.Path(tempfile.gettempdir()) / 'my_suite.py')
+    with open(module_file, 'w+') as handle:
+        handle.write(module)
+
+    suite = load_suite(module_file)
+    qtbot.addWidget(suite)
+    assert isinstance(suite, typhon.TyphonSuite)
+    assert suite.devices == []
+
+
+def test_load_suite_with_bad_py_file():
+    with pytest.raises(AttributeError):
+        suite = load_suite(typhon.utils.__file__)

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,12 +1,12 @@
 __all__ = ['TyphonDeviceDisplay', 'use_stylesheet',
            'register_signal', 'TyphonSuite', 'TyphonSignalPanel',
-           'TyphonPositionerWidget', 'TyphonMethodButton']
+           'TyphonPositionerWidget', 'TyphonMethodButton', 'load_suite']
 from .display import TyphonDeviceDisplay
 from .func import TyphonMethodButton
 from .suite import TyphonSuite
 from .signal import TyphonSignalPanel
 from .positioner import TyphonPositionerWidget
-from .utils import use_stylesheet
+from .utils import use_stylesheet, load_suite
 from .plugins import register_signal
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -55,11 +55,11 @@ def typhon_cli_setup(args):
         return
 
     # Deal with stylesheet
-    logger.debug("Applying stylesheet ...")
     if not app:
         logger.debug("Creating QApplication ...")
         app = QApplication([])
 
+    logger.debug("Applying stylesheet ...")
     typhon.use_stylesheet(dark=args.dark)
     if args.stylesheet:
         logger.info("Loading QSS file %r ...", args.stylesheet)

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import QApplication
 import typhon
 
 logger = logging.getLogger(__name__)
+app = None
 
 # Argument Parser Setup
 parser = argparse.ArgumentParser(description='Create a TyphonSuite for '
@@ -35,9 +36,8 @@ parser.add_argument('--stylesheet',
 __doc__ += '\n::\n\n    ' + parser.format_help().replace('\n', '\n    ')
 
 
-def typhon_cli(args):
-    args = parser.parse_args(args)
-
+def typhon_cli_setup(args):
+    global app
     # Logging Level handling
     if args.verbose:
         level = "DEBUG"
@@ -54,31 +54,41 @@ def typhon_cli(args):
         print(f'Typhon: Version {typhon.__version__} from {typhon.__file__}')
         return
 
-    try:
-        import happi
-    except (ImportError, ModuleNotFoundError):
-        logger.exception("Unable to import happi to load devices!")
-        return
-
-    logger.debug("Creating Happi Client ...")
-    client = happi.Client.from_config(cfg=args.happi_cfg)
-
-    logger.debug("Creating widgets ...")
-    app = QApplication.instance()
+    # Deal with stylesheet
+    logger.debug("Applying stylesheet ...")
     if not app:
+        logger.debug("Creating QApplication ...")
         app = QApplication([])
 
+    typhon.use_stylesheet(dark=args.dark)
     if args.stylesheet:
         logger.info("Loading QSS file %r ...", args.stylesheet)
         with open(args.stylesheet, 'r') as handle:
             app.setStyleSheet(handle.read())
 
+
+def create_suite(devices, cfg=None):
+    """Create a TyphonSuite from a list of device names"""
+    logger.debug("Accessing Happi Client ...")
+    try:
+        import happi
+        import typhon.plugins.happi
+    except (ImportError, ModuleNotFoundError):
+        logger.exception("Unable to import happi to load devices!")
+        return
+    if typhon.plugins.happi._client:
+        logger.debug("Using happi Client already registered with Typhon")
+        client = typhon.plugins.happi._client
+    else:
+        logger.debug("Creating new happi Client from configuration")
+        client = happi.Client.from_config(cfg=cfg)
+    logger.debug("Creating empty TyphonSuite ...")
     suite = typhon.TyphonSuite()
     logger.info("Loading Tools ...")
     for name, tool in suite.default_tools.items():
         suite.add_tool(name, tool())
     # Load and add each device
-    for device in args.devices:
+    for device in devices:
         logger.info("Loading %r ...", device)
         try:
             device = client.load_device(name=device)
@@ -86,14 +96,21 @@ def typhon_cli(args):
             suite.show_subdisplay(device)
         except Exception:
             logger.exception("Unable to add %r to TyphonSuite", device)
-
-    # Deal with stylesheet
-    typhon.use_stylesheet(dark=args.dark)
-    logger.info("Launching application ...")
-    suite.show()
-    app.exec_()
-    logger.info("Execution complete!")
     return suite
+
+
+def typhon_cli(args):
+    """Command Line Application for Typhon"""
+    args = parser.parse_args(args)
+    typhon_cli_setup(args)
+    if not args.version:
+        suite = create_suite(args.devices, cfg=args.happi_cfg)
+        if suite:
+            suite.show()
+            logger.info("Launching application ...")
+            QApplication.instance().exec_()
+            logger.info("Execution complete!")
+            return suite
 
 
 def main():

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -1,7 +1,7 @@
 ############
 # Standard #
 ############
-import pathlib
+import os
 from functools import partial
 import logging
 
@@ -368,7 +368,7 @@ class TyphonSuite(TyphonBase):
         location of the created Python file
         """
         logger.debug("Requesting file location for saved TyphonSuite")
-        root_dir = str(pathlib.Path(__file__).parent)
+        root_dir = os.getcwd()
         filename = QFileDialog.getSaveFileName(self, 'Save TyphonSuite',
                                                root_dir, "Python (*.py)")
         if filename:

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -363,7 +363,7 @@ class TyphonSuite(TyphonBase):
 
     def save(self):
         """
-        Save the TyphonSuite to a Python file using :meth:`typhon.utils.save_suite`
+        Save the TyphonSuite to a file using :meth:`typhon.utils.save_suite`
 
         A ``QFileDialog`` will be used to query the user for the desired
         location of the created Python file
@@ -386,10 +386,8 @@ class TyphonSuite(TyphonBase):
         else:
             logger.debug("No filename chosen")
 
-
     # Add the template to the docstring
     save.__doc__ += textwrap.indent('\n' + saved_template, '\t\t')
-
 
     def _get_sidebar(self, widget):
         items = {}

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -4,6 +4,7 @@
 import os
 from functools import partial
 import logging
+import textwrap
 
 ############
 # External #
@@ -17,7 +18,7 @@ from qtpy.QtWidgets import (QDockWidget, QHBoxLayout, QVBoxLayout, QWidget,
 ###########
 from .display import TyphonDeviceDisplay
 from .utils import (clean_name, TyphonBase, flatten_tree, raise_to_operator,
-                    save_suite)
+                    save_suite, saved_template)
 from .widgets import TyphonSidebarItem, SubDisplay
 from .tools import TyphonTimePlot, TyphonLogDisplay, TyphonConsole
 
@@ -362,10 +363,14 @@ class TyphonSuite(TyphonBase):
 
     def save(self):
         """
-        Save the TyphonSuite to a Python file using :meth:`.save_suite`
+        Save the TyphonSuite to a Python file using :meth:`typhon.utils.save_suite`
 
         A ``QFileDialog`` will be used to query the user for the desired
         location of the created Python file
+
+        The template will be of the form:
+
+        .. code::
         """
         logger.debug("Requesting file location for saved TyphonSuite")
         root_dir = os.getcwd()
@@ -380,6 +385,11 @@ class TyphonSuite(TyphonBase):
                 raise_to_operator(exc)
         else:
             logger.debug("No filename chosen")
+
+
+    # Add the template to the docstring
+    save.__doc__ += textwrap.indent('\n' + saved_template, '\t\t')
+
 
     def _get_sidebar(self, widget):
         items = {}

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -361,7 +361,12 @@ class TyphonSuite(TyphonBase):
         return display
 
     def save(self):
-        """Save the TyphonSuite to a Python file using :meth:`.save_suite`"""
+        """
+        Save the TyphonSuite to a Python file using :meth:`.save_suite`
+
+        A ``QFileDialog`` will be used to query the user for the desired
+        location of the created Python file
+        """
         logger.debug("Requesting file location for saved TyphonSuite")
         root_dir = str(pathlib.Path(__file__).parent)
         filename = QFileDialog.getSaveFileName(self, 'Save TyphonSuite',

--- a/typhon/suite.py
+++ b/typhon/suite.py
@@ -376,7 +376,7 @@ class TyphonSuite(TyphonBase):
                 with open(filename[0], 'w+') as handle:
                     save_suite(self, handle)
             except Exception as exc:
-                logger.error("Failed to save TyphonSuite")
+                logger.exception("Failed to save TyphonSuite")
                 raise_to_operator(exc)
         else:
             logger.debug("No filename chosen")

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -265,7 +265,16 @@ def reload_widget_stylesheet(widget, cascade=False):
 
 
 def save_suite(suite, file_or_buffer):
-    """Create a file capable of relaunching the TyphonSuite"""
+    """
+    Create a file capable of relaunching the TyphonSuite
+
+    Parameters
+    ----------
+    suite: TyphonSuite
+
+    file_or_buffer : str or file-like
+        Either a path to the file or a handle that supports ``write``
+    """
     # Accept file-like objects or a handle
     if isinstance(file_or_buffer, str):
         handle = open(file_or_buffer, 'w+')
@@ -277,7 +286,19 @@ def save_suite(suite, file_or_buffer):
 
 
 def load_suite(path):
-    """"Load a file saved via Typhon"""
+    """"
+    Load a file saved via Typhon
+
+    Parameters
+    ----------
+    path: str
+        Path to file describing the ``TyphonSuite``. This needs to be of the
+        format created by the :meth:`.save_suite` function.
+
+    Returns
+    -------
+    suite: TyphonSuite
+    """
     logger.info("Importing TyphonSuite from file %r ...", path)
     module_name = pathlib.Path(path).name.replace('.py', '')
     spec = importlib.util.spec_from_file_location(module_name,

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -297,7 +297,7 @@ import typhon.cli
 
 devices = {devices}
 
-def create_suite(cfg):
+def create_suite(cfg=None):
     return typhon.cli.create_suite(devices, cfg=cfg)
 
 if __name__ == '__main__':

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -260,3 +260,29 @@ def reload_widget_stylesheet(widget, cascade=False):
         for child in widget.children():
             if isinstance(child, QWidget):
                 reload_widget_stylesheet(child, cascade=True)
+
+
+def save_suite(suite, file_or_buffer):
+    """Create a file capable of relaunching the TyphonSuite"""
+    # Accept file-like objects or a handle
+    if isinstance(file_or_buffer, str):
+        handle = open(file_or_buffer, 'w+')
+    else:
+        handle = file_or_buffer
+    logger.debug("Saving TyphonSuite contents to %r", handle)
+    devices = [device.name for device in suite.devices]
+    handle.write(saved_template.format(devices=devices))
+
+
+saved_template = """\
+import sys
+import typhon.cli
+
+devices = {devices}
+
+def create_suite(cfg):
+    return typhon.cli.create_suite(devices, cfg=cfg)
+
+if __name__ == '__main__':
+    typhon.cli.typhon_cli(devices + sys.argv[1:])
+"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Woo hoo! Closing the 4th oldest issue in the library.

The idea here is if I add a bunch of devices to my `TyphonSuite` then decide I will want to reload this later, how can I save and reload this object. After a conversation with @klauer and @hhslepicka I decided to see how the route of actually saving the Python code required to generate the ``TyphonSuite`` looked. A button was added to the ParameterTree so that this is available via the GUI.

I did something which I think is clever here and broke up the `typhon.cli` library in order make a terse template that either can be executed as a standalone Python script or imported and used as part of a bigger Qt application. By using the `typhon.cli` you will still have access to all the additional options:

```
$ python my_saved_suite.py --verbose
```

But I can load as many `TyphonSuite` files as I want using `typhon.load_suite`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #17 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added for all new utilities


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Narrative doc page added with explanation, API docs as well.



## Screenshots (if appropriate):

<img width="265" alt="screen shot 2019-02-04 at 8 59 33 pm" src="https://user-images.githubusercontent.com/25753048/52253972-db065280-28bf-11e9-9016-913c98d9da36.png">