### PR TITLE
Array Data

### DIFF
--- a/examples/panel.py
+++ b/examples/panel.py
@@ -12,7 +12,7 @@ class Sample(Device):
     readback = Cpt(SignalRO, value=1)
     setpoint = Cpt(Signal, value=2)
     waveform = Cpt(SignalRO, value=np.random.randn(100, ))
-    image = Cpt(SignalRO, value=np.random.randn((100, 100)) * 455)
+    image = Cpt(SignalRO, value=np.abs(np.random.randn(100, 100)) * 455)
 
 
 # Create my device without a prefix

--- a/examples/panel.py
+++ b/examples/panel.py
@@ -12,7 +12,7 @@ class Sample(Device):
     readback = Cpt(SignalRO, value=1)
     setpoint = Cpt(Signal, value=2)
     waveform = Cpt(SignalRO, value=np.random.randn(100, ))
-    image = Cpt(SignalRO, value=np.ones((100, 100)) * 455)
+    image = Cpt(SignalRO, value=np.random.randn((100, 100)) * 455)
 
 
 # Create my device without a prefix

--- a/examples/panel.py
+++ b/examples/panel.py
@@ -1,0 +1,30 @@
+"""Example to create a Panel of Ophyd Signals from an object"""
+import sys
+import numpy as np
+from ophyd import Device, Component as Cpt, Signal
+from ophyd.sim import SignalRO
+from qtpy.QtWidgets import QApplication
+import typhon
+
+
+class Sample(Device):
+    """Simulated Device"""
+    readback = Cpt(SignalRO, value=1)
+    setpoint = Cpt(Signal, value=2)
+    waveform = Cpt(SignalRO, value=np.random.randn(100, ))
+    image = Cpt(SignalRO, value=np.ones((100, 100)) * 455)
+
+
+# Create my device without a prefix
+sample = Sample('', name='sample')
+
+if __name__ == '__main__':
+    # Create my application
+    app = QApplication(sys.argv)
+    typhon.use_stylesheet()
+    # Create my panel
+    panel = typhon.TyphonSignalPanel.from_device(sample)
+    panel.sortBy = panel.byName
+    # Execute
+    panel.show()
+    app.exec_()

--- a/tests/plugins/test_core.py
+++ b/tests/plugins/test_core.py
@@ -5,6 +5,7 @@
 ############
 # External #
 ############
+import numpy as np
 from ophyd import Signal
 from pydm.widgets.base import PyDMWritableWidget
 from qtpy.QtWidgets import QWidget
@@ -102,3 +103,24 @@ def test_disconnection(qtbot):
     # This should fail on the get
     sig.subscribable = True
     sig_conn = SignalConnection(listener, 'broken_signal')
+
+
+def test_array_signal_send_value(qapp, qtbot):
+    sig = Signal(name='my_array', value=np.ones(4))
+    register_signal(sig)
+    widget = WritableWidget()
+    qtbot.addWidget(widget)
+    widget.channel = 'sig://my_array'
+    qapp.processEvents()
+    assert all(widget.value == np.ones(4))
+
+
+def test_array_signal_put_value(qapp, qtbot):
+    sig = Signal(name='my_array_write', value=np.ones(4))
+    register_signal(sig)
+    widget = WritableWidget()
+    qtbot.addWidget(widget)
+    widget.channel = 'sig://my_array_write'
+    widget.send_value_signal[np.ndarray].emit(np.zeros(4))
+    qapp.processEvents()
+    assert all(sig.value == np.zeros(4))

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -5,6 +5,7 @@
 ############
 # External #
 ############
+import numpy as np
 from ophyd import Kind
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
 from ophyd.sim import SynSignal, SynSignalRO
@@ -14,7 +15,8 @@ from qtpy.QtWidgets import QWidget
 ###########
 # Package #
 ###########
-from typhon.signal import SignalPanel, TyphonSignalPanel
+from typhon.signal import SignalPanel, TyphonSignalPanel, signal_widget
+from typhon.widgets import ImageDialogButton, WaveformDialogButton
 from .conftest import show_widget, RichSignal, DeadSignal
 
 @using_fake_epics_pv
@@ -143,3 +145,22 @@ def test_typhon_panel_sorting(qapp, client, qtbot):
     key_order = list(panel.layout().signals.keys())
     assert key_order[0] == 'readback'
     assert key_order[-1] == 'unused'
+    return panel
+
+
+@show_widget
+def test_signal_widget_waveform(qtbot):
+    signal = Signal(name='test_wave', value=np.zeros((4, )))
+    widget = signal_widget(signal)
+    qtbot.addWidget(widget)
+    assert isinstance(widget, WaveformDialogButton)
+    return widget
+
+
+@show_widget
+def test_signal_widget_image(qtbot):
+    signal = Signal(name='test_img', value=np.zeros((400, 540)))
+    widget = signal_widget(signal)
+    qtbot.addWidget(widget)
+    assert isinstance(widget, ImageDialogButton)
+    return widget

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -65,7 +65,12 @@ def signal_widget(signal, read_only=False):
                      signal.name)
         desc = {}
     # Unshaped data
-    if desc.get('shape', []) == []:
+    shape = desc.get('shape', [])
+    try:
+        dimensions = len(shape)
+    except TypeError:
+        dimensions = 0
+    if dimensions == 0:
         # Check for enum_strs, if so create a QCombobox
         if read_only:
             logger.debug("Creating Label for %s", signal.name)

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -246,7 +246,9 @@ class SignalDialogButton(QPushButton):
     text = NotImplemented
     icon = NotImplemented
 
-    def __init__(self, init_channel, parent=None):
+    def __init__(self, init_channel, text=None, icon=None, parent=None):
+        self.text = text or self.text
+        self.icon = icon or self.icon
         super().__init__(qta.icon(self.icon), self.text, parent=parent)
         self.clicked.connect(self.show_dialog)
         self.dialog = None

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -264,6 +264,7 @@ class SignalDialogButton(QPushButton):
             logger.debug("Creating QDialog for %r", self.channel)
             # Set up the QDialog
             self.dialog = QDialog(self)
+            self.dialog.setWindowTitle(self.channel)
             self.dialog.setLayout(QVBoxLayout())
             self.dialog.layout().setContentsMargins(2, 2, 2, 2)
             # Add the widget

--- a/typhon/widgets.py
+++ b/typhon/widgets.py
@@ -286,7 +286,7 @@ class ImageDialogButton(SignalDialogButton):
     def widget(self):
         """Create PyDMImageView"""
         return PyDMImageView(parent=self,
-                             image_channel=[self.channel])
+                             image_channel=self.channel)
 
 
 class WaveformDialogButton(SignalDialogButton):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Previously `typhon` just threw array data on the floor when it found it in a `Signal`. With this PR we now create a `QPushButton` that either launches a `PyDMWaveformPlot` for a one-dimensional array or a `PyDMImageView` for two-dimensional. Unfortunately, PyDM doesn't deal with colored images so still can't handle that.

I think this is better for the long term instead of just showing them directly inside the grid. It doesn't scale well for multiple arrays, but I'm open to alternative opinions. My thought is you can always customize your template to include a full size widget.

I also think that using my test suite to visually check all the widgets might have reached a tipping point. I put a small examples folder in with a fake device and panel to mess around with.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #97 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests for new widgets and in context of `signal_widget` creation

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
New `examples` added

## Screenshots (if appropriate):
![panel_with_arrays](https://user-images.githubusercontent.com/25753048/52459390-b0173b00-2b19-11e9-81d5-447231b7e708.gif)
