### PR TITLE
REF: proof-of-concept for hiding Q_ENUMS a bit better

### DIFF
--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -1,6 +1,7 @@
 ############
 # Standard #
 ############
+from enum import IntEnum
 from functools import partial
 import logging
 
@@ -9,14 +10,14 @@ import logging
 ############
 from ophyd import Kind
 from ophyd.signal import EpicsSignal, EpicsSignalBase, EpicsSignalRO
-from qtpy.QtCore import Property, Q_ENUMS, QSize
+from qtpy.QtCore import Property, QSize
 from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel)
 
 #############
 #  Package  #
 #############
 from .utils import (channel_name, clear_layout, clean_attr, grab_kind,
-                    is_signal_ro, TyphonBase)
+                    is_signal_ro, TyphonBase, UsesEnums)
 from .widgets import (TyphonLineEdit, TyphonComboBox, TyphonLabel,
                       TyphonDesignerMixin, ImageDialogButton,
                       WaveformDialogButton)
@@ -213,18 +214,17 @@ class SignalPanel(QGridLayout):
         return loc
 
 
-class SignalOrder:
+class SignalOrder(IntEnum):
     """Option to sort signals"""
     byKind = 0
     byName = 1
 
 
-class TyphonSignalPanel(TyphonBase, TyphonDesignerMixin, SignalOrder):
+class TyphonSignalPanel(UsesEnums(SignalOrder),
+                        TyphonBase, TyphonDesignerMixin):
     """
     Panel of Signals for Device
     """
-    Q_ENUMS(SignalOrder)  # Necessary for display in Designer
-    SignalOrder = SignalOrder  # For convenience
     # From top of page to bottom
     kind_order = (Kind.hinted, Kind.normal,
                   Kind.config, Kind.omitted)

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -220,8 +220,10 @@ class SignalOrder(IntEnum):
     byName = 1
 
 
-class TyphonSignalPanel(UsesEnums(SignalOrder),
-                        TyphonBase, TyphonDesignerMixin):
+QtSignalOrder = UsesEnums(SignalOrder)
+
+
+class TyphonSignalPanel(QtSignalOrder, TyphonBase, TyphonDesignerMixin):
     """
     Panel of Signals for Device
     """


### PR DESCRIPTION
_Concept:_
This is the best I've been able to come up with due to how PyQt implements `Q_ENUMS` under the hood. **This doesn't have to be merged.**

The return value of the `UsesEnums` helper is actually a base class, so that's why it's in camel case:

Usage:
```python
class TyphonSignalPanel(UsesEnums(SignalOrder), TyphonBase, TyphonDesignerMixin):
```

I thought about that a bit more, then found I liked the following better:
```python
QtSignalOrder = UsesEnums(SignalOrder)

class TyphonSignalPanel(QtSignalOrder, TyphonBase, TyphonDesignerMixin):
```

If the contents of this PR are really found to be desirable, I think just renaming to `make_qt_enum_base_class` or something along those lines would probably be the next step. Then making all other classes use it.

_Proof:_
![image](https://user-images.githubusercontent.com/5139267/53913949-5c611a00-4011-11e9-8faf-f3b9298a9fbb.png)

Reference:
PyQt4: https://github.com/Werkov/PyQt4/blob/master/qpy/QtCore/qpycore_qmetaobject.cpp#L45
PyQt5: https://github.com/baoboa/pyqt5/blob/master/qpy/QtCore/qpycore_enums_flags.cpp