### PR TITLE
ENH: add tooltips to function buttons + parameters

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
       - qtconsole
       - qtpy
       - timechart
+      - numpydoc
 
 test:
     imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ qtconsole
 qtpy
 pyqtgraph
 ophyd
+numpydoc

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -171,9 +171,9 @@ def test_func_docstrings(qtbot):
     # Check that all our methods made it in
     assert fp.methods['foo'].docs['summary'] == 'The function foo'
     params = fp.methods['foo'].docs['params']
-    assert params['a'].desc == ['A special A']
-    assert params['b'].desc == ['The infamous B parameter (default: False)']
-    assert params['c'].desc == ['The ill-named C parameter (default: True)']
+    assert params['a'] == ['A special A']
+    assert params['b'] == ['The infamous B parameter (default: False)']
+    assert params['c'] == ['The ill-named C parameter (default: True)']
 
     assert fp.methods['foobar'].docs['summary'] == 'docstring2'
     return fp

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -134,3 +134,46 @@ def test_method_button_use_status(qtbot, method_button):
     assert not method_button._status_thread is None
     qtbot.waitUntil(lambda : not method_button.isEnabled(), timeout=5000)
     qtbot.waitUntil(method_button.isEnabled, timeout=5000)
+
+
+@show_widget
+def test_func_docstrings(qtbot):
+    # Mock functions
+    def foo(a: int, b: bool=False, c: bool=True):
+        '''
+        The function foo
+
+        Parameters
+        ----------
+        a : int
+            A special A
+
+        b : bool, optional
+            The infamous B parameter (default: False)
+
+        c : bool, optional
+            The ill-named C parameter (default: True)
+
+        Notes
+        -----
+        Note #1
+        Note #2
+        '''
+        pass
+
+    def foobar(a: float, b: str, c: float=3.14, d: bool=False):
+        'docstring2'
+        pass
+
+    # Create Panel
+    fp = FunctionPanel([foo, foobar])
+    qtbot.addWidget(fp)
+    # Check that all our methods made it in
+    assert fp.methods['foo'].docs['summary'] == 'The function foo'
+    params = fp.methods['foo'].docs['params']
+    assert params['a'].desc == ['A special A']
+    assert params['b'].desc == ['The infamous B parameter (default: False)']
+    assert params['c'].desc == ['The ill-named C parameter (default: True)']
+
+    assert fp.methods['foobar'].docs['summary'] == 'docstring2'
+    return fp

--- a/typhon/func.py
+++ b/typhon/func.py
@@ -408,7 +408,7 @@ class FunctionDisplay(QGroupBox):
                 logger.debug('Parameter information is not available '
                              'for %s(%s)', self.name, name)
             else:
-                 if doc_param:
+                if doc_param:
                     tooltip.extend(doc_param)
 
             # If the tooltip is just the header, remove the dashes underneath:

--- a/typhon/func.py
+++ b/typhon/func.py
@@ -442,8 +442,7 @@ class FunctionDisplay(QGroupBox):
             # Add the control widget to our contents
             self.optional.contents.layout().addWidget(cntrl)
 
-        if tooltip is not None:
-            cntrl.setToolTip(tooltip)
+        cntrl.param_label.setToolTip(tooltip)
         return cntrl
 
     def sizeHint(self):


### PR DESCRIPTION
Closes #171

If numpydoc is decided to be too heavy of a dependency, this could be made optional.

Example
---------
![image](https://user-images.githubusercontent.com/5139267/53920583-7c4d0980-4022-11e9-9b1a-65cd002493fe.png)
![image](https://user-images.githubusercontent.com/5139267/53920609-8f5fd980-4022-11e9-94da-7ae9198fd11f.png)
