### PR TITLE
Small bugs

### DIFF
--- a/tests/plugins/test_core.py
+++ b/tests/plugins/test_core.py
@@ -18,19 +18,11 @@ from typhon.plugins.core import (SignalPlugin, SignalConnection,
                                  register_signal)
 
 
-
-class WritableWidget(PyDMLineEdit):
-    """Simple Testing Widget"""
-    pass
-
-
-
-
 def test_signal_connection(qapp, qtbot):
     # Create a signal and attach our listener
     sig = Signal(name='my_signal', value=1)
     register_signal(sig)
-    widget = WritableWidget()
+    widget = PyDMLineEdit()
     qtbot.addWidget(widget)
     widget.channel = 'sig://my_signal'
     listener = widget.channels()[0]
@@ -71,7 +63,7 @@ def test_signal_connection(qapp, qtbot):
 
 
 def test_metadata(qapp, qtbot):
-    widget = WritableWidget()
+    widget = PyDMLineEdit()
     qtbot.addWidget(widget)
     widget.channel = 'sig://md_signal'
     listener = widget.channels()[0]
@@ -87,7 +79,7 @@ def test_metadata(qapp, qtbot):
 
 
 def test_disconnection(qtbot):
-    widget = WritableWidget()
+    widget = PyDMLineEdit()
     qtbot.addWidget(widget)
     widget.channel = 'sig://invalid'
     listener = widget.channels()[0]
@@ -108,7 +100,7 @@ def test_disconnection(qtbot):
 def test_array_signal_send_value(qapp, qtbot):
     sig = Signal(name='my_array', value=np.ones(4))
     register_signal(sig)
-    widget = WritableWidget()
+    widget = PyDMLineEdit()
     qtbot.addWidget(widget)
     widget.channel = 'sig://my_array'
     qapp.processEvents()
@@ -118,7 +110,7 @@ def test_array_signal_send_value(qapp, qtbot):
 def test_array_signal_put_value(qapp, qtbot):
     sig = Signal(name='my_array_write', value=np.ones(4))
     register_signal(sig)
-    widget = WritableWidget()
+    widget = PyDMLineEdit()
     qtbot.addWidget(widget)
     widget.channel = 'sig://my_array_write'
     widget.send_value_signal[np.ndarray].emit(np.zeros(4))

--- a/tests/plugins/test_core.py
+++ b/tests/plugins/test_core.py
@@ -7,7 +7,7 @@
 ############
 import numpy as np
 from ophyd import Signal
-from pydm.widgets.base import PyDMWritableWidget
+from pydm.widgets import PyDMLineEdit
 from qtpy.QtWidgets import QWidget
 
 ###########
@@ -19,7 +19,7 @@ from typhon.plugins.core import (SignalPlugin, SignalConnection,
 
 
 
-class WritableWidget(QWidget, PyDMWritableWidget):
+class WritableWidget(PyDMLineEdit):
     """Simple Testing Widget"""
     pass
 

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -153,7 +153,11 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
                                         macros=macros)
             # Add device to all children widgets
             if self.devices:
-                for widget in self._main_widget.findChildren(TyphonBase):
+                designer = (self._main_widget.findChildren(TyphonDesignerMixin)
+                            or [])
+                bases = (self._main_widget.findChildren(TyphonBase)
+                         or [])
+                for widget in set(bases + designer):
                     widget.add_device(self.devices[0])
         except (FileNotFoundError, IsADirectoryError):
             logger.exception("Unable to load file %r", self.current_template)

--- a/typhon/func.py
+++ b/typhon/func.py
@@ -495,6 +495,7 @@ class TyphonMethodButton(QPushButton, TyphonDesignerMixin):
             logger.exception("Error executing method %r.",
                              self.method_name)
             raise_to_operator(exc)
+            return
         if self.use_status:
             logger.debug("Tearing down any old status threads ...")
             if self._status_thread and self._status_thread.isRunning():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Found a few of these when setting up the demo and also included a patch that is required after https://github.com/slaclab/pydm/pull/470

1. If we fail to call a function it will not produce a `Status`. We now have a check to see that we are ready for this scenario.
2. Not all widgets inherit from `TyphonBase`, the `TyphonMethodButton` for instance. We still want to auto populate as much as we can, i.e if a user drags in a `TyphonMethodButton` into their template we should fill it.
3. The `_unit` variable no longer exists on `PyDMWidgetBase` but instead only on widgets that inherit from `TextFormatter`. Simply using ` PyDMLineEdit` in the test will work and be back compatible. 