### PR TITLE
FIX: Double SignalDialogButton

### DIFF
--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -31,14 +31,17 @@ def test_panel_creation(qtbot):
                     'Read Only': EpicsSignalRO('Tst:Pv:RO'),
                     # Simulated Signal
                     'Simulated': SynSignal(name='simul'),
-                    'SimulatedRO': SynSignalRO(name='simul_ro')})
+                    'SimulatedRO': SynSignalRO(name='simul_ro'),
+                    'Array': Signal(name='array', value=np.ones((5, 10)))})
     widget = QWidget()
     qtbot.addWidget(widget)
     widget.setLayout(panel)
-    assert len(panel.signals) == 5
+    assert len(panel.signals) == 6
     # Check read-only channels do not have write widgets
     panel.layout().itemAtPosition(2, 1).layout().count() == 1
     panel.layout().itemAtPosition(4, 1).layout().count() == 1
+    # Array widget has only a button, even when writable
+    assert panel.layout().itemAtPosition(5, 1).layout().count() == 1
     # Check write widgets are present
     panel.layout().itemAtPosition(0, 1).layout().count() == 2
     panel.layout().itemAtPosition(1, 1).layout().count() == 2

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -19,7 +19,7 @@ from .utils import (channel_name, clear_layout, clean_attr, grab_kind,
                     is_signal_ro, TyphonBase)
 from .widgets import (TyphonLineEdit, TyphonComboBox, TyphonLabel,
                       TyphonDesignerMixin, ImageDialogButton,
-                      WaveformDialogButton)
+                      WaveformDialogButton, SignalDialogButton)
 from .plugins import register_signal
 
 
@@ -149,7 +149,8 @@ class SignalPanel(QGridLayout):
         # Create the read-only signal
         read = signal_widget(signal, read_only=True)
         # Create the write signal
-        if not is_signal_ro(signal):
+        if (not is_signal_ro(signal) and not isinstance(read,
+                                                        SignalDialogButton)):
             write = signal_widget(signal)
         else:
             write = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
We were creating the same widget twice for an writeable array. Someday we'll have a widget that can write back to an array but I don't quite see a use case at the moment. For now, there is no point of having two identical buttons next to each other in the panel. Regression test added. 

Closes #177 