### PR TITLE
CLI Cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # Standard #
 ############
 import os.path
+import pathlib
 import logging
 from functools import wraps
 
@@ -183,3 +184,9 @@ def client():
                                       'happi.json'))
     register_client(client)
     return client
+
+
+@pytest.fixture(scope='session')
+def happi_cfg():
+    path = pathlib.Path(__file__)
+    return str(path.parent / 'happi.cfg')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,9 @@
 import os
-import pathlib
 
 import pytest
 
 import typhon
 from typhon.cli import typhon_cli, QApplication
-
-
-@pytest.fixture(scope='session')
-def happi_cfg():
-    path = pathlib.Path(__file__)
-    return str(path.parent / 'happi.cfg')
 
 
 def test_cli_version(capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,16 @@ def test_cli_happi_cfg(monkeypatch, qtbot, happi_cfg):
     assert suite.isVisible()
     assert 'test_motor' == suite.devices[0].name
 
+def test_cli_bad_entry(qtbot, happi_cfg):
+    suite = typhon_cli(['no_motor', '--happi-cfg', happi_cfg])
+    assert suite is None
+
+def test_cli_no_entry(monkeypatch, qtbot, happi_cfg):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    suite = typhon_cli(['--happi-cfg', happi_cfg])
+    qtbot.addWidget(suite)
+    assert suite.isVisible()
+    assert suite.devices == []
 
 def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,30 +15,31 @@ def test_cli_version(capsys):
 
 def test_cli_happi_cfg(monkeypatch, qtbot, happi_cfg):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
-    suite = typhon_cli(['test_motor', '--happi-cfg', happi_cfg])
-    qtbot.addWidget(suite)
-    assert suite.isVisible()
-    assert 'test_motor' == suite.devices[0].name
+    window = typhon_cli(['test_motor', '--happi-cfg', happi_cfg])
+    qtbot.addWidget(window)
+    assert window.isVisible()
+    assert 'test_motor' == window.centralWidget().devices[0].name
 
 def test_cli_bad_entry(qtbot, happi_cfg):
-    suite = typhon_cli(['no_motor', '--happi-cfg', happi_cfg])
-    assert suite is None
+    window = typhon_cli(['no_motor', '--happi-cfg', happi_cfg])
+    assert window is None
 
 def test_cli_no_entry(monkeypatch, qtbot, happi_cfg):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
-    suite = typhon_cli(['--happi-cfg', happi_cfg])
-    qtbot.addWidget(suite)
-    assert suite.isVisible()
-    assert suite.devices == []
+    window = typhon_cli(['--happi-cfg', happi_cfg])
+    qtbot.addWidget(window)
+    assert window.isVisible()
+    assert window.centralWidget().devices == []
 
 def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
     with open('test.qss', 'w+') as handle:
         handle.write("TyphonDeviceDisplay {qproperty-force_template: 'test.ui'}")
     style = qapp.styleSheet()
-    suite = typhon_cli(['test_motor', '--stylesheet', 'test.qss',
+    window = typhon_cli(['test_motor', '--stylesheet', 'test.qss',
                         '--happi-cfg', happi_cfg])
-    qtbot.addWidget(suite)
+    qtbot.addWidget(window)
+    suite = window.centralWidget()
     dev_display = suite.get_subdisplay(suite.devices[0])
     assert dev_display.force_template == 'test.ui'
     qapp.setStyleSheet(style)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -10,8 +10,7 @@ def test_log_display(qtbot):
     log_tool = TyphonLogDisplay.from_device(dev)
     qtbot.addWidget(log_tool)
     dev.log.error(dev.name)
-    assert dev.name in log_tool.logdisplay.text.toPlainText()
+    assert log_tool.logdisplay.handler in dev.log.handlers
     dev2 = Device(name='blah')
     log_tool.add_device(dev2)
-    dev2.log.info(dev2.name)
-    assert dev2.name in log_tool.logdisplay.text.toPlainText()
+    assert log_tool.logdisplay.handler in dev2.log.handlers

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,17 +79,18 @@ def test_raise_to_operator_msg(monkeypatch, qtbot):
     assert 'ZeroDivisionError' in exc_dialog.text()
 
 
-def test_load_suite(qtbot):
+def test_load_suite(qtbot, happi_cfg):
     # Setup new saved file
-    module = saved_template.format(devices=[])
+    module = saved_template.format(devices=['test_motor'])
     module_file = str(pathlib.Path(tempfile.gettempdir()) / 'my_suite.py')
     with open(module_file, 'w+') as handle:
         handle.write(module)
 
-    suite = load_suite(module_file)
+    suite = load_suite(module_file, happi_cfg)
     qtbot.addWidget(suite)
     assert isinstance(suite, typhon.TyphonSuite)
-    assert suite.devices == []
+    assert len(suite.devices) == 1
+    assert suite.devices[0].name == 'test_motor'
     os.remove(module_file)
 
 

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -97,7 +97,8 @@ def create_suite(devices, cfg=None):
         logger.info("Loading Tools ...")
         for name, tool in suite.default_tools.items():
             suite.add_tool(name, tool())
-        logger.info("Adding devices ...")
+        if devices:
+            logger.info("Adding devices ...")
         for device in loaded_devs:
             try:
                 suite.add_device(device)

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -91,7 +91,7 @@ def create_suite(devices, cfg=None):
             loaded_devs.append(device)
         except Exception:
             logger.exception("Unable to load %r", device)
-    if loaded_devs:
+    if loaded_devs or not devices:
         logger.debug("Creating empty TyphonSuite ...")
         suite = typhon.TyphonSuite()
         logger.info("Loading Tools ...")

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -40,11 +40,10 @@ def typhon_cli_setup(args):
     global app
     # Logging Level handling
     logging.getLogger().addHandler(logging.NullHandler())
+    shown_logger = logging.getLogger('typhon')
     if args.verbose:
         level = "DEBUG"
-        shown_logger = logging.getLogger('typhon')
     else:
-        shown_logger = logging.getLogger()
         level = "INFO"
     coloredlogs.install(level=level, logger=shown_logger,
                         fmt='[%(asctime)s] - %(levelname)s -  %(message)s')

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -39,6 +39,7 @@ __doc__ += '\n::\n\n    ' + parser.format_help().replace('\n', '\n    ')
 def typhon_cli_setup(args):
     global app
     # Logging Level handling
+    logging.getLogger().addHandler(logging.NullHandler())
     if args.verbose:
         level = "DEBUG"
         shown_logger = logging.getLogger('typhon')

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -82,21 +82,30 @@ def create_suite(devices, cfg=None):
     else:
         logger.debug("Creating new happi Client from configuration")
         client = happi.Client.from_config(cfg=cfg)
-    logger.debug("Creating empty TyphonSuite ...")
-    suite = typhon.TyphonSuite()
-    logger.info("Loading Tools ...")
-    for name, tool in suite.default_tools.items():
-        suite.add_tool(name, tool())
     # Load and add each device
+    loaded_devs = list()
     for device in devices:
         logger.info("Loading %r ...", device)
         try:
             device = client.load_device(name=device)
-            suite.add_device(device)
-            suite.show_subdisplay(device)
+            loaded_devs.append(device)
         except Exception:
-            logger.exception("Unable to add %r to TyphonSuite", device)
-    return suite
+            logger.exception("Unable to load %r", device)
+    if loaded_devs:
+        logger.debug("Creating empty TyphonSuite ...")
+        suite = typhon.TyphonSuite()
+        logger.info("Loading Tools ...")
+        for name, tool in suite.default_tools.items():
+            suite.add_tool(name, tool())
+        logger.info("Adding devices ...")
+        for device in loaded_devs:
+            try:
+                suite.add_device(device)
+                suite.show_subdisplay(device)
+            except Exception:
+                logger.exception("Unable to add %r to TyphonSuite",
+                                 device.name)
+        return suite
 
 
 def typhon_cli(args):

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -122,7 +122,7 @@ def typhon_cli(args):
             logger.info("Launching application ...")
             QApplication.instance().exec_()
             logger.info("Execution complete!")
-            return suite
+            return window
 
 
 def main():

--- a/typhon/cli.py
+++ b/typhon/cli.py
@@ -4,7 +4,7 @@ import logging
 import sys
 
 import coloredlogs
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QMainWindow
 
 import typhon
 
@@ -116,7 +116,9 @@ def typhon_cli(args):
     if not args.version:
         suite = create_suite(args.devices, cfg=args.happi_cfg)
         if suite:
-            suite.show()
+            window = QMainWindow()
+            window.setCentralWidget(suite)
+            window.show()
             logger.info("Launching application ...")
             QApplication.instance().exec_()
             logger.info("Execution complete!")

--- a/typhon/tools/log.py
+++ b/typhon/tools/log.py
@@ -10,7 +10,11 @@ class TyphonLogDisplay(TyphonBase):
     """Typhon Logging Display"""
     def __init__(self, level=logging.INFO, parent=None):
         super().__init__(parent=parent)
-        self.logdisplay = PyDMLogDisplay(level=level)
+        # Set the logname to be non-existant so that we do not attach to the
+        # root logger. This causes issue if this widget is closed before the
+        # end of the Python session. For the long term this issue will be
+        # resolved with https://github.com/slaclab/pydm/issues/474  
+        self.logdisplay = PyDMLogDisplay(logname='not_set', level=level)
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(self.logdisplay)
 

--- a/typhon/tools/log.py
+++ b/typhon/tools/log.py
@@ -13,7 +13,7 @@ class TyphonLogDisplay(TyphonBase):
         # Set the logname to be non-existant so that we do not attach to the
         # root logger. This causes issue if this widget is closed before the
         # end of the Python session. For the long term this issue will be
-        # resolved with https://github.com/slaclab/pydm/issues/474  
+        # resolved with https://github.com/slaclab/pydm/issues/474
         self.logdisplay = PyDMLogDisplay(logname='not_set', level=level)
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(self.logdisplay)

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -295,6 +295,9 @@ def load_suite(path, cfg=None):
         Path to file describing the ``TyphonSuite``. This needs to be of the
         format created by the :meth:`.save_suite` function.
 
+    cfg: str, optional
+        Location of happi configuration file to use to load devices. If not
+        entered the ``$HAPPI_CFG`` environment variable will be used.
     Returns
     -------
     suite: TyphonSuite

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -285,7 +285,7 @@ def save_suite(suite, file_or_buffer):
     handle.write(saved_template.format(devices=devices))
 
 
-def load_suite(path):
+def load_suite(path, cfg=None):
     """"
     Load a file saved via Typhon
 
@@ -307,7 +307,7 @@ def load_suite(path):
     spec.loader.exec_module(suite_module)
     if hasattr(suite_module, 'create_suite'):
         logger.debug("Executing create_suite method from %r", suite_module)
-        return suite_module.create_suite()
+        return suite_module.create_suite(cfg=cfg)
     else:
         raise AttributeError("Imported module has no 'create_suite' method!")
 


### PR DESCRIPTION
Noticed then when actually trying out the `typhon.cli` in the wild. If you mistype your device name i.e: `typhon not_a_device`. The CLI goes through all the trouble of creating a `TyphonSuite` for you that contains **no** devices. Not optimal.

This PR rearranges the code in the CLI function so we exit as early as possible if you entered malformed device information. The code is a little messier but I think this is better for the end user. The other commits were centered around the fact that I created and loaded a device-less `TyphonSuite` to test the command line interface so those tests had to be updated.

Closes #184 