### PR TITLE
Child Access through HappiPlugin

### DIFF
--- a/tests/plugins/test_happi.py
+++ b/tests/plugins/test_happi.py
@@ -33,6 +33,16 @@ def test_connection(client):
     hp.remove_connection(hc2)
     assert hp.connections == {}
 
+
+def test_connection_for_child(client):
+    hp = HappiPlugin()
+    mock = Mock()
+    hc = HappiChannel(address='happi://test_motor.setpoint', tx_slot=mock)
+    hp.add_connection(hc)
+    tx = mock.call_args[0][0]
+    assert tx['obj'].name == 'test_motor_setpoint'
+
+
 def test_bad_address_smoke(client):
     hp = HappiPlugin()
     hc = HappiChannel(address='happi://not_a_device', tx_slot=lambda x: None)

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -103,7 +103,7 @@ class HappiPlugin(PyDMPlugin):
             logger.error("Unable to find device for %r in happi database.",
                          channel)
         except AttributeError as exc:
-            logger.error("Invalid attribute %r for address %r",
-                         exc, channel.address)
+            logger.exception("Invalid attribute %r for address %r",
+                             exc, channel.address)
         except Exception:
             logger.exception("Unable to load %r from happi", channel.address)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If we have a device in `happi` which has a component device that we want a screen for say `reference_laser.y`, we want to be able to grab these devices easily. This PR supports dotted access to components as specified in the channel:

`happi://reference_laser.y`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #182 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added

## Screenshots (if appropriate):

![child_access](https://user-images.githubusercontent.com/25753048/54391582-7aa6c580-4662-11e9-9130-6c6a8d3d3b22.gif)
