### PR TITLE
ENH: component.doc

### DIFF
--- a/typhon/positioner.py
+++ b/typhon/positioner.py
@@ -145,7 +145,8 @@ class TyphonPositionerWidget(TyphonBase, TyphonDesignerMixin):
             self._readback = device.user_readback
         else:
             # Let us assume it is the first hint
-            self._readback = grab_kind(device, 'hinted')[0][1]
+            hinted = list(grab_kind(device, 'hinted').values())[0]
+            self._readback = hinted.signal
         register_signal(self._readback)
         self.ui.user_readback.channel = channel_from_signal(self._readback)
         # Limit values

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -293,19 +293,16 @@ class TyphonSignalPanel(TyphonBase, TyphonDesignerMixin, SignalOrder):
         shown_kind = [kind for kind in Kind if self._kinds[kind.name]]
         # Iterate through kinds
         signals = list()
-        for kind in Kind:
-            if kind in shown_kind:
-                try:
-                    for (attr, signal) in grab_kind(self.devices[0],
-                                                    kind.name):
-                        label = clean_attr(attr)
-                        # Check twice for Kind as signal might have multiple
-                        # kinds
-                        if signal.kind in shown_kind:
-                            signals.append((label, signal))
-                except Exception:
-                    logger.exception("Unable to add %s signals from %r",
-                                     kind.name, self.devices[0])
+        for kind in shown_kind:
+            try:
+                for (attr, signal) in grab_kind(self.devices[0], kind.name):
+                    label = clean_attr(attr)
+                    # Check twice for Kind as signal might have multiple kinds
+                    if signal.kind in shown_kind:
+                        signals.append((label, signal))
+            except Exception:
+                logger.exception("Unable to add %s signals from %r",
+                                 kind.name, self.devices[0])
         # Pick our sorting function
         if self._signal_order == SignalOrder.byKind:
 

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -152,7 +152,7 @@ class SignalPanel(QGridLayout):
         """
         logger.debug("Adding signal %s", name)
         # Create the read-only signal
-        read = signal_widget(signal, read_only=True, tooltip=tooltip)
+        read = signal_widget(signal, read_only=True)
         # Create the write signal
         if (not is_signal_ro(signal) and not isinstance(read,
                                                         SignalDialogButton)):
@@ -160,7 +160,7 @@ class SignalPanel(QGridLayout):
         else:
             write = None
         # Add to the layout
-        return self._add_row(read, name, write=write)
+        return self._add_row(read, name, write=write, tooltip=tooltip)
 
     def add_pv(self, read_pv, name, write_pv=None):
         """
@@ -195,10 +195,12 @@ class SignalPanel(QGridLayout):
         clear_layout(self)
         self.signals.clear()
 
-    def _add_row(self, read, name, write=None):
+    def _add_row(self, read, name, write=None, tooltip=None):
         # Create label
         label = QLabel()
         label.setText(name)
+        if tooltip is not None:
+            label.setToolTip(tooltip)
         # Create signal display
         val_display = QHBoxLayout()
         # Add readback

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel)
 #  Package  #
 #############
 from .utils import (channel_name, clear_layout, clean_attr, grab_kind,
-                    GrabKindItem, is_signal_ro, TyphonBase)
+                    is_signal_ro, TyphonBase)
 from .widgets import (TyphonLineEdit, TyphonComboBox, TyphonLabel,
                       TyphonDesignerMixin, ImageDialogButton,
                       WaveformDialogButton, SignalDialogButton)

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -56,7 +56,22 @@ def is_signal_ro(signal):
 
 
 def grab_kind(device, kind):
-    """Grab all signals of a specific Kind from a Device instance"""
+    """
+    Grab all signals of a specific Kind from a Device instance
+
+    Parameters
+    ----------
+    device : ophyd.Device
+        The device instance to introspect
+    kind : Kind or str
+        The kind to search for
+
+    Returns
+    -------
+    signals : dict
+        Keyed on attribute name, the signals dict contains GrabKindItem named
+        tuples, which have attributes {attr, component, signal}.
+    """
     # Accept actual Kind or string value
     if not isinstance(kind, Kind):
         kind = Kind[kind]


### PR DESCRIPTION
Suggested as a follow-up to #174 by @teddyrendahl 

Use Component docstrings when creating Typhon widgets

Closes #167 

Example screenshot:
![image](https://user-images.githubusercontent.com/5139267/54625768-20747e80-4a2d-11e9-9d7a-106646da52a3.png)
