### PR TITLE
MAINT: Move HappiChannel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/slaclab/pydm.git
 git+https://github.com/pcdshub/QDarkStyleSheet.git
+git+https://github.com/slaclab/timechart.git
 coloredlogs
 numpy
 qtawesome

--- a/tests/plugins/test_happi.py
+++ b/tests/plugins/test_happi.py
@@ -8,8 +8,8 @@ import pytest
 
 import typhon
 import typhon.plugins
-from typhon.plugins.happi import HappiPlugin, HappiChannel
-
+from typhon.plugins.happi import HappiPlugin
+from typhon.widgets import HappiChannel
 
 
 def test_connection(client):

--- a/typhon/plugins/__init__.py
+++ b/typhon/plugins/__init__.py
@@ -12,8 +12,7 @@ logger = logging.getLogger(__name__)
 add_plugin(SignalPlugin)
 
 try:
-    from .happi import (HappiPlugin, HappiConnection, HappiChannel,
-                        register_client)
+    from .happi import HappiPlugin, HappiConnection, register_client
     add_plugin(HappiPlugin)
 except ImportError:
     logger.warning("Unable to import HappiPlugin")

--- a/typhon/plugins/happi.py
+++ b/typhon/plugins/happi.py
@@ -4,8 +4,7 @@ from happi import Client
 from happi.loader import from_container
 from happi.errors import SearchError
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
-from pydm.widgets.channel import PyDMChannel
-from qtpy.QtCore import Signal, Slot, QObject
+from qtpy.QtCore import Signal
 
 _client = None
 logger = logging.getLogger(__name__)
@@ -20,34 +19,6 @@ def register_client(client):
     """
     global _client
     _client = client
-
-
-class HappiChannel(PyDMChannel, QObject):
-    """
-    PyDMChannel to transport Device Information
-
-    Parameters
-    ----------
-    tx_slot: callable
-        Slot on widget to accept a dictionary of both the device and metadata
-        information
-    """
-    def __init__(self, *, tx_slot, **kwargs):
-        super().__init__(**kwargs)
-        QObject.__init__(self)
-        self._tx_slot = tx_slot
-        self._last_md = None
-
-    @Slot(dict)
-    def tx_slot(self, value):
-        """Transmission Slot"""
-        # Do not fire twice for the same device
-        if not self._last_md or self._last_md != value['md']:
-            self._last_md = value['md']
-            self._tx_slot(value)
-        else:
-            logger.debug("HappiChannel %r received same device. "
-                         "Ignoring for now ...", self)
 
 
 class HappiConnection(PyDMConnection):


### PR DESCRIPTION
Not sure how my the test included in #150 didn't catch this, I'll take a closer look at a later date. This will fix the issue where `HappiChannel` was not being imported when `happi` is not present. In actuality `HappiChannel` has no `happi` dependency so it can be moved to an accessible location inside the main library.

Closes #198 