### PR TITLE
FIX: PYQTDESIGNERPATH variable should not be expanded

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -13,7 +13,7 @@ ACTIVATE=$PREFIX/etc/conda/activate.d/typhon.sh
 DEACTIVATE=$PREFIX/etc/conda/deactivate.d/typhon.sh
 
 echo "from typhon.designer import *" >> $DESIGNER_PLUGIN
-echo "export PYQTDESIGNERPATH="$DESIGNER_PLUGIN_PATH":$PYQTDESIGNERPATH" >> $ACTIVATE
+echo "export PYQTDESIGNERPATH="$DESIGNER_PLUGIN_PATH":\$PYQTDESIGNERPATH" >> $ACTIVATE
 echo "export PYDM_DESIGNER_ONLINE=True" >> $ACTIVATE
 echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE
 


### PR DESCRIPTION
`PYQTDESIGNERPATH` is not set when the CONDA package is built. With macro expansion this leaves the activation file as:

`export $PYQTDESIGNERPATH=/path/to/my/module/designer.py:`

This obviously does not work when multiple libraries plan on loading designer plugins. This has the side affect of not clearing the variable when you activate a new CONDA environment. However, as long as these libraries are setup to `unset` on deactivation you should have no problem switching.