### PR TITLE
FIX: certain char array PVs should show as strings

### DIFF
--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -109,7 +109,7 @@ def signal_widget(signal, read_only=False, tooltip=None):
     widget_instance.setObjectName(name)
     if tooltip is not None:
         widget_instance.setToolTip(tooltip)
-    if dtype == 'string':
+    if dtype == 'string' and widget in (TyphonLabel, TyphonLineEdit):
         widget_instance.displayFormat = DisplayFormat.String
     return widget_instance
 

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -70,6 +70,7 @@ def signal_widget(signal, read_only=False, tooltip=None):
         desc = {}
     # Unshaped data
     shape = desc.get('shape', [])
+    dtype = desc.get('dtype', '')
     try:
         dimensions = len(shape)
     except TypeError:
@@ -108,11 +109,8 @@ def signal_widget(signal, read_only=False, tooltip=None):
     widget_instance.setObjectName(name)
     if tooltip is not None:
         widget_instance.setToolTip(tooltip)
-    try:
-        if signal.as_string:
-            widget_instance.displayFormat = DisplayFormat.String
-    except AttributeError:
-        pass
+    if dtype == 'string':
+        widget_instance.displayFormat = DisplayFormat.String
     return widget_instance
 
 

--- a/typhon/signal.py
+++ b/typhon/signal.py
@@ -9,6 +9,7 @@ import logging
 ############
 from ophyd import Kind
 from ophyd.signal import EpicsSignal, EpicsSignalBase, EpicsSignalRO
+from pydm.widgets.display_format import DisplayFormat
 from qtpy.QtCore import Property, Q_ENUMS, QSize
 from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel)
 
@@ -107,6 +108,11 @@ def signal_widget(signal, read_only=False, tooltip=None):
     widget_instance.setObjectName(name)
     if tooltip is not None:
         widget_instance.setToolTip(tooltip)
+    try:
+        if signal.as_string:
+            widget_instance.displayFormat = DisplayFormat.String
+    except AttributeError:
+        pass
     return widget_instance
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When the signal is noted to be a string (e.g. `Cpt(EpicsSignal, ':TEXT', string=True`), make sure it is displayed as a string in the ui.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Char arrays default to showing the integer values, but these are often used to hold string data and expect the client to translate.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Worked for me, but clearly needs some more rigor.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
