### PR TITLE
Use PyPI on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,14 @@ matrix:
            - PYDM_CHANNEL=pcds-tag
      - python: 3.6
        env: PYDM_CHANNEL=pydm-dev
+     - python: 3.6
+       env: PYDM_CHANNEL=None
      - python: 3.7
        env:
            - PYDM_CHANNEL=pcds-tag
            - BUILD=1
      - python: 3.7
+       env: PYDM_CHANNEL=None
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -37,17 +40,31 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
-  - conda config --add channels $PYDM_CHANNEL 
   - conda config --append channels pcds-tag
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
-  # Grab all dependencies
-  - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
-  - conda config --add channels "file://`pwd`/bld-dir"
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION typhon --file dev-requirements.txt
-  # Launch Conda environment
-  - source activate test-environment
+  - |
+    # Install all dependencies via CONDA
+    if [[ $PYDM_CHANNEL != "None" ]]; then
+      conda config --add channels $PYDM_CHANNEL
+      # Use the recipe contained inside the repository to build packcage
+      conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
+      # Install package with development dependencies
+      conda config --add channels "file://`pwd`/bld-dir"
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION typhon --file dev-requirements.txt
+      # Launch Conda environment
+      source activate test-environment
+    # Install all dependencies via PIP
+    else
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip
+      # Launch Conda environment
+      source activate test-environment
+      # Install package
+      python setup.py install
+      # Add our dependencies
+      pip install -r dev-requirements.txt
+    fi
   # Setup some path environment variables for epics
   - export PATH=$PATH:$EPICS_BASE/bin/$EPICS_HOST_ARCH
   - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$EPICS_BASE/lib/$EPICS_HOST_ARCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,7 @@ matrix:
        env:
            - PYDM_CHANNEL=pcds-tag
            - BUILD=1
-  allow_failures:
      - python: 3.7
-       env:
-           - PYDM_CHANNEL=pcds-tag
-           - BUILD=1
-
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
       # Install package
       python setup.py install
       # Add our dependencies
-      pip install git+https://github.com/pcdshub/happi.git -r dev-requirements.txt
+      pip install git+https://github.com/pcdshub/happi.git PyQt5 -r dev-requirements.txt
     fi
   # Setup some path environment variables for epics
   - export PATH=$PATH:$EPICS_BASE/bin/$EPICS_HOST_ARCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     apt:
       packages:
         - herbstluftwm
-
+        - libxkbcommon-x11-0
 env:
   global:
     - OFFICIAL_REPO="pcdshub/typhon"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
       # Install package
       python setup.py install
       # Add our dependencies
-      pip install -r dev-requirements.txt
+      pip install git+https://github.com/pcdshub/happi.git -r dev-requirements.txt
     fi
   # Setup some path environment variables for epics
   - export PATH=$PATH:$EPICS_BASE/bin/$EPICS_HOST_ARCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ matrix:
      - python: 3.6
        env: PYDM_CHANNEL=pydm-dev
      - python: 3.6
-       env: PYDM_CHANNEL=None
+       env: PYDM_CHANNEL=pip
      - python: 3.7
        env:
            - PYDM_CHANNEL=pcds-tag
            - BUILD=1
      - python: 3.7
-       env: PYDM_CHANNEL=None
+       env: PYDM_CHANNEL=pip
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -46,7 +46,7 @@ install:
   - conda info -a
   - |
     # Install all dependencies via CONDA
-    if [[ $PYDM_CHANNEL != "None" ]]; then
+    if [[ $PYDM_CHANNEL != "pip" ]]; then
       conda config --add channels $PYDM_CHANNEL
       # Use the recipe contained inside the repository to build packcage
       conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir

--- a/README.md
+++ b/README.md
@@ -45,12 +45,18 @@ environment variables will be setup in such a way that the Typhon widgets will
 immediately be available in the `QtDesigner`. Otherwise, see the
 ``typhon_env.sh`` script contained in the ``etc`` folder of this repository.
 
+`happi` is an optional dependency but is recommended. This must be installed
+manually if not using the CONDA recipe.
+
 ### Qt Installation
 There have been some observed inconsistencies between installations of `Qt`
 available on `pip`, `defaults` and `conda-forge`. It is recommended that if you
 want to use the full `typhon` feature to install via `conda-forge`. We have
 found this the most reliable, especially when it comes to using the
-`QtDesigner`.
+`QtDesigner`. It is worth noting that since this library uses `qtpy` as an
+interface layer to the various options for Qt Python bindings, the bare
+requirements will not install a specific one for you. The testing suite runs
+using `PyQt5`.
 
 ## Getting Started
 Creating your first ``typhon`` panel for an``ophyd.Device`` only takes two

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 codecov
 doctr
 flake8
-happi
 ipython
 matplotlib
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ pytest-qt
 pytest-timeout
 sphinx
 sphinx_rtd_theme
+simplejson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-git+https://github.com/slaclab/pydm.git
-git+https://github.com/pcdshub/QDarkStyleSheet.git
-git+https://github.com/slaclab/timechart.git
+pydm
+qdarkstyle
+timechart
 coloredlogs
 numpy
 qtawesome


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
External collaborators seem to prefer `pip` installing instead of using our CONDA channel. Since both `timechart` and `pydm` are both now on PyPI I decided it was time to add this as a branch in our testing suite and officially support this installation pattern.

Also since Python 3.7 is passing now, I'm removing it from the `allowed_failures` list 🎉 

