### PR TITLE
ENH: Python file as a template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ matrix:
        env: PYDM_CHANNEL=pydm-dev
      - python: 3.6
        env: PYDM_CHANNEL=pip
-     - python: 3.7
+     - python: 3.7.3  # Pinned due to PyDM bug with Python 3.7.4
        env:
            - PYDM_CHANNEL=pcds-tag
            - BUILD=1
-     - python: 3.7
+     - python: 3.7.3  # Pinned due to PyDM bug with Python 3.7.4
        env: PYDM_CHANNEL=pip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ matrix:
        env: PYDM_CHANNEL=pydm-dev
      - python: 3.6
        env: PYDM_CHANNEL=pip
-     - python: 3.7.3  # Pinned due to PyDM bug with Python 3.7.4
+     - python: 3.7.3  # Pinned due to PyQt bug. Remove when PyQt 5.13.1 is available
        env:
            - PYDM_CHANNEL=pcds-tag
            - BUILD=1
-     - python: 3.7.3  # Pinned due to PyDM bug with Python 3.7.4
+     - python: 3.7.3  # Pinned due to PyQt bug. Remove when PyQt 5.13.1 is available
        env: PYDM_CHANNEL=pip
 
 install:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -2,6 +2,7 @@ import os.path
 
 import pytest
 
+from pydm import Display
 from typhon import TyphonDeviceDisplay
 from typhon.utils import clean_attr
 
@@ -93,3 +94,12 @@ def test_display_device_name_property(motor, display):
     assert display.device_name == ''
     display.add_device(motor)
     assert display.device_name == motor.name
+
+
+def test_display_with_py_file(display):
+    py_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           'utils/display.py')
+    display.templates['detailed_screen'] = py_file
+    display.load_template()
+    assert isinstance(display._main_widget, Display)
+    assert getattr(display._main_widget, 'is_from_test_file', False)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -57,7 +57,6 @@ def test_panel_creation(qtbot):
     panel.layout().itemAtPosition(0, 1).layout().count() == 2
     panel.layout().itemAtPosition(1, 1).layout().count() == 2
     panel.layout().itemAtPosition(3, 1).layout().count() == 2
-    return panel
 
 
 def test_panel_add_enum(qtbot):
@@ -75,7 +74,6 @@ def test_panel_add_enum(qtbot):
     but_layout = panel.layout().itemAtPosition(loc1, 1)
     assert isinstance(but_layout.itemAt(but_layout.count()-1).widget(),
                       PyDMEnumComboBox)
-    return panel
 
 
 def test_add_dead_signal(qtbot):

--- a/tests/utils/display.py
+++ b/tests/utils/display.py
@@ -1,0 +1,9 @@
+from pydm import Display
+
+
+class TestDisplay(Display):
+    is_from_test_file = True
+
+    # HACK to load a UI-less file
+    def ui_filepath(self):
+        return None

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -153,7 +153,7 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
             ext = os.path.splitext(self.current_template)[1]
             # Support Python files
             if ext == '.py':
-                logger.debug("Loading as a Python file ...")
+                logger.debug("Loading %r as a Python file ...", self.current_template)
                 self._main_widget = load_py_file(self.current_template,
                                                  macros=self._last_macros)
             # Otherwise assume you have given use a UI file

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -153,7 +153,8 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
             ext = os.path.splitext(self.current_template)[1]
             # Support Python files
             if ext == '.py':
-                logger.debug("Loading %r as a Python file ...", self.current_template)
+                logger.debug("Loading %r as a Python file ...",
+                             self.current_template)
                 self._main_widget = load_py_file(self.current_template,
                                                  macros=self._last_macros)
             # Otherwise assume you have given use a UI file

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -139,18 +139,16 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
             logger.debug("Clearing existing layout ...")
             clear_layout(self.layout())
         # Assemble our macros
-        macros = macros or dict()
+        self._last_macros = macros or self._last_macros
         for display_type in self.templates:
-            value = macros.get(display_type)
+            value = self._last_macros.get(display_type)
             if value:
                 logger.debug("Found new template %r for %r",
                              value, display_type)
                 self.templates[display_type] = value
-        # Store macros
-        self._last_macros = macros
         try:
             self._main_widget = Display(ui_filename=self.current_template,
-                                        macros=macros)
+                                        macros=self._last_macros)
             # Add device to all children widgets
             if self.devices:
                 designer = (self._main_widget.findChildren(TyphonDesignerMixin)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This allows a user to specify a Python file instead of a `.ui` as a Typhon template. The Python file must contain a subclass of the `pydm.Display` in accordance with the mandates required by PyDM

@hhslepicka Is this the correct future-proof way of doing this? Seemed pretty easy. Don't know why I was whining so much in the linked issue

I also found a bug where calling `TyphonDeviceDisplay.load_template` without any macros overwrote the cached macros from prior loads which kind of made caching the macros pointless. This is now remedied. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #201 