### PR TITLE
DEV: Patch TyphonConsole in test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,13 +22,16 @@ from pydm import PyDMApplication
 ###########
 import typhon
 from typhon.plugins.happi import register_client
-
+from typhon.utils import TyphonBase
 
 logger = logging.getLogger(__name__)
 
 # Global testing variables
 show_widgets = False
 application = None
+
+# Path TyphonConsole on TyphonSuite
+typhon.TyphonSuite.default_tools['Console'] = TyphonBase
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ logger = logging.getLogger(__name__)
 show_widgets = False
 application = None
 
-# Path TyphonConsole on TyphonSuite
+# Patch TyphonConsole on TyphonSuite. Creation of more than one QtConsole
+# quicky in the test suite causes instabilities
 typhon.TyphonSuite.default_tools['Console'] = TyphonBase
 
 


### PR DESCRIPTION
This fixed some problems I found locally with the test suite. The issue is that the QtConsole wants to spawn a Jupyter kernel behind it. Standing a bunch of these up and down in rapid succession seems cause ... issues. This may be a worrying sign or maybe just something that happens in test suites and not elsewhere.